### PR TITLE
Fix multiline strings not allowed in bytecode

### DIFF
--- a/omni_vm/src/main.rs
+++ b/omni_vm/src/main.rs
@@ -38,12 +38,32 @@ fn eval_string(input: &str) -> Result<Value, VmPanic> {
     }
 
     let mut output = String::new();
-
+    let mut peek = false;
+    let mut broken = false;
     for c in iter {
-        match c {
-            other => output.push(other),
+        if peek {
+            if c == 'n' {
+                output.push('\n');
+            } else {
+                output.push(c)
+            }
+            peek = false;
+            continue;
         }
+        if c == '\\' {
+            peek = true;
+            continue;
+        }
+        if c == ';' {
+            broken = true;
+            break;
+        }
+        output.push(c);
     }
+    if !broken {
+        return Err(VmPanic::InvalidBytecode)
+    }
+
     match tag.parse::<i8>() {
         Ok(v) => match Value::new(v, output.as_str()) {
             Ok(v) => Ok(v),

--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -47,6 +47,7 @@ impl VmError {
 pub enum VmPanic {
     TagConversionFailed,
     UnexpectedValue,
+    InvalidBytecode
 }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/src/omni_script/main.py
+++ b/src/omni_script/main.py
@@ -1059,7 +1059,7 @@ class Compiler:
 
         output.append('.const')
         for const in self.constants:
-            output.append(f'{const[0]};{str(const[1])}')
+            output.append(f'{const[0]};{str(const[1]).replace('\n', '\\n').replace(';', '\\;')};')
         output.append('.code')
         for instr in self.code:
             output.append(' '.join(map(str, instr)))


### PR DESCRIPTION
Fixes #10

## Summary by Sourcery

Handle escaped newlines and delimiters in constant strings when compiling and evaluating bytecode.

Bug Fixes:
- Allow multiline and semicolon-containing strings to be safely represented in compiled bytecode constants and correctly reconstructed at runtime.
- Detect and error on malformed or unterminated bytecode constant strings instead of silently accepting them.

Enhancements:
- Introduce an explicit InvalidBytecode panic variant to represent invalid constant encodings during bytecode evaluation.