### PR TITLE
Add +=, /=. *=, and -=

### DIFF
--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -620,6 +620,24 @@ fn div(a: Value, b: Value) -> Result<Value, VmError> {
         }),
     }
 }
+fn vm_mod(a: Value, b: Value) -> Result<Value, VmError> {
+    match (&a, &b) {
+        (Value::Integer(va), Value::Integer(vb)) => Ok(Value::Integer(va % vb)),
+        (Value::Float(va), Value::Integer(vb)) => Ok(Value::Float(va % *vb as f64)),
+
+        (Value::Integer(va), Value::Float(vb)) => Ok(Value::Float(*va as f64 % vb)),
+        (Value::Float(va), Value::Float(vb)) => Ok(Value::Float(va % vb)),
+
+        _ => Err(VmError {
+            msg: format!(
+                "TypeError: Cannot apply modulo a {} with a {}",
+                a.display(),
+                b.display()
+            ),
+            errcode: ErrCode::TypeError,
+        }),
+    }
+}
 fn mul(a: Value, b: Value) -> Result<Value, VmError> {
     match (&a, &b) {
         (Value::Integer(va), Value::Integer(vb)) => Ok(Value::Integer(va * vb)),
@@ -813,6 +831,7 @@ static FUNCS: Lazy<HashMap<String, fn(Value, Value) -> Result<Value, VmError>>> 
     fs.insert("ADD".to_string(), add);
     fs.insert("MULTIPLY".to_string(), mul);
     fs.insert("DIV".to_string(), div);
+    fs.insert("MOD".to_string(), vm_mod);
     fs.insert("SUBTRACT".to_string(), sub);
     fs.insert("POW".to_string(), pow);
     fs.insert("LESS_THAN".to_string(), lt);

--- a/src/omni_compiler/main.py
+++ b/src/omni_compiler/main.py
@@ -66,7 +66,7 @@ PLUS_ASSIGN = "PLUS_ASSIGN"
 SUB_ASSIGN = 'SUB_ASSIGN'
 MUL_ASSIGN = 'MUL_ASSIGN'
 DIV_ASSIGN = 'DIV_ASSIGN'
-
+MOD = 'MOD'
 
 @dataclass
 class CompilationException(Exception):
@@ -296,6 +296,9 @@ class Tokenizer:
         elif current_char == "<":
             self.advance(1)
             return Token(LESS_THAN, None, start_line, start_col, self.line, self.col)
+        elif current_char == '%':
+            self.advance(1)
+            return Token(MOD, None, start_line, start_col, self.line, self.col)
         elif current_char == ">":
             self.advance(1)
             return Token(GREATER_THAN, None, start_line, start_col, self.line, self.col)
@@ -580,7 +583,7 @@ class Parser:
 
     def term(self):
         node = self.power()
-        while self.current_token and self.current_token.type in (MUL, DIV):
+        while self.current_token and self.current_token.type in (MUL, DIV, MOD):
             op = self.current_token.type
             self.eat(op)
             node = BinOp(
@@ -1139,7 +1142,6 @@ class UnaryOp(ASTNode):
 
 @dataclass
 class BinOp(ASTNode):
-
     left: ASTNode
     op: str
     right: ASTNode
@@ -1227,6 +1229,7 @@ OP_AND = AND
 OP_CALL = "CALL"
 NEG = "NEG"
 OP_NEG = NEG
+OP_MOD = MOD
 OP_NOT = NOT
 OPCODE_MAP = {
     ADD: OP_ADD,
@@ -1244,6 +1247,7 @@ OPCODE_MAP = {
     AND: OP_AND,
     NEG: OP_NEG,
     NOT: OP_NOT,
+    MOD: OP_MOD
 }
 BUILTIN = "BUILTIN"
 NULL = "NULL"


### PR DESCRIPTION
Resolves #29.
Checklist:
- [x] `+=`, `/=`, `*=`, and `-=`
- [x] `%`

## Summary by Sourcery

Add support for compound assignment operators and modulo across the tokenizer, parser, and VM runtime.

New Features:
- Support +=, -=, *=, and /= compound assignment syntax in the parser by lowering them to equivalent binary operations.
- Introduce % modulo operator in expressions with corresponding tokenizer, parser, opcode mapping, and VM implementation.

Enhancements:
- Clean up assorted formatting and spacing in parser and compiler code for readability.