### PR TITLE
Add runtime values

### DIFF
--- a/devvm
+++ b/devvm
@@ -1,3 +1,3 @@
 #!/bin/bash
-uv run build_vm.py
+uv run build_vm.py && \
 dist/omvm "$@"

--- a/omni_vm/src/main.rs
+++ b/omni_vm/src/main.rs
@@ -7,7 +7,7 @@ use std::process::exit;
 use std::rc::Rc;
 use std::{fs, vec};
 mod runtime;
-use runtime::{ErrCode, OmniFunc};
+use runtime::{ErrCode, Export, OmniFunc, RuntimeType};
 
 #[derive(Parser)]
 struct Cli {
@@ -108,6 +108,7 @@ struct VM {
     frames: Vec<Frame>,
     sources: Vec<Source>,
     source_select: Vec<usize>,
+    mod_stack: Vec<String>,
 }
 #[derive(Debug, Clone)]
 struct Frame {
@@ -349,6 +350,7 @@ impl VM {
             frames: vec![frame],
             sources,
             source_select,
+            mod_stack: vec!["[main]".to_string()],
         })
     }
     //fn global_env(mut self, env: &[Value]) -> Self {
@@ -510,7 +512,15 @@ impl VM {
                 "PUSH_BUILTIN" => {
                     let item: Value =
                         self.global_env[operators[1].parse::<usize>().unwrap()].clone();
-                    self.push_to_stack(Rc::new(item));
+                    let to_push = match item {
+                        Value::RuntimeValue(t) => match t {
+                            RuntimeType::Name => {
+                                Value::String(self.mod_stack.last().expect("Module stack underflow").to_string())
+                            }
+                        },
+                        _ => item,
+                    };
+                    self.push_to_stack(Rc::new(to_push));
                 }
                 "BREAK" => {
                     println!("Breakpoint: at {}:", self.frames.last().unwrap().name);
@@ -556,7 +566,7 @@ impl VM {
                     };
                     let out = match attrl.as_ref() {
                         Value::Module(m) => match m.exports.get(attrand) {
-                            Some(v) => v.clone(),
+                            Some(v) => v.clone().val,
                             None => {
                                 return Err(VmError {
                                     msg: format!(
@@ -752,7 +762,9 @@ impl VM {
                             param_count,
                             closure,
                             name,
+                            module
                         } => {
+                            self.mod_stack.push(module.to_string());
                             let mut fenv = Env {
                                 values: vec![None; *local_count],
                                 parent: Some(closure.clone()),
@@ -761,6 +773,15 @@ impl VM {
                             let mut rust_args: Vec<Option<ValueRef>> = vec![];
                             for arg in args {
                                 rust_args.push(Some(arg))
+                            }
+                            if *param_count != arg_count {
+                                return Err(VmError {
+                                    msg: format!(
+                                        "Expected {} args, got {}",
+                                        param_count, arg_count
+                                    ),
+                                    errcode: ErrCode::InvalidArgCount,
+                                });
                             }
                             for i in 0..*param_count {
                                 fenv.values[i] = rust_args[i].clone()
@@ -807,6 +828,7 @@ impl VM {
                     let return_addr: usize = self.frames.last().unwrap().ret_addr.unwrap();
                     self.frames.last_mut().unwrap().i = return_addr;
                     self.frames.pop();
+                    self.mod_stack.pop();
                     self.push_to_stack(to_ret);
                 }
                 "NEG" => {
@@ -854,12 +876,65 @@ impl VM {
                     };
                     self.push_to_stack(out);
                 }
-
+                "ENTER_MODULE" => {
+                    let mod_name_idx = operators[1].parse::<usize>().expect("Invalid Bytecode");
+                    let mod_name = match self.const_pool.get(mod_name_idx) {
+                        None => {
+                            return Err(VmError {
+                                msg: format!(
+                                    "Could not find a value in the constant pool at index {}",
+                                    mod_name_idx
+                                ),
+                                errcode: ErrCode::ValueError,
+                            });
+                        }
+                        Some(v) => match v {
+                            Value::String(s) => s,
+                            _ => {
+                                return Err(VmError {
+                                    msg: format!(
+                                        "Expected ENTER_MODULE to reference a string, not a {}",
+                                        v.display()
+                                    ),
+                                    errcode: ErrCode::TypeError,
+                                });
+                            }
+                        },
+                    };
+                    self.mod_stack.push(mod_name.to_string());
+                }
                 "MAKE_MODULE" => {
+                    let mod_name_tmp = self
+                        .const_pool
+                        .get(operators[1].parse::<usize>().expect("Invalid Bytecode"));
+                    let mod_name = match mod_name_tmp {
+                        None => {
+                            return Err(VmError {
+                                msg: format!(
+                                    "Could not find a value from the constant pool at index {}",
+                                    operators[1]
+                                ),
+                                errcode: ErrCode::ValueError,
+                            });
+                        }
+                        Some(v) => match v {
+                            Value::String(s) => s,
+                            _ => {
+                                return Err(VmError {
+                                    msg: format!(
+                                        "Expected `MAKE_MODULE` to reference a string, not a {}",
+                                        v.display()
+                                    ),
+                                    errcode: ErrCode::TypeError,
+                                });
+                            }
+                        },
+                    };
                     let new_mod = Module {
                         exports: self.frames.last().unwrap().env.borrow().exports.clone(),
-                        name: None,
+                        name: mod_name.to_string(),
                     };
+                    self.mod_stack.pop();
                     self.push_to_stack(Rc::new(Value::Module(new_mod)));
                 }
 
@@ -913,7 +988,21 @@ impl VM {
                         .env
                         .borrow_mut()
                         .exports
-                        .insert(name.to_string(), to_ex);
+                        .insert(
+                            name.to_string(),
+                            Export {
+                                name: match self.mod_stack.last() {
+                                    Some(v) => v.to_string(),
+                                    None => {
+                                        return Err(VmError {
+                                            msg: "Module stack underflow".to_string(),
+                                            errcode: ErrCode::StackUnderflow,
+                                        });
+                                    }
+                                },
+                                val: to_ex,
+                            },
+                        );
                 }
                 "MAKE_FUNCTION" => {
                     let entry: usize = operators[1].parse().expect("Invalid bytecode");
@@ -937,6 +1026,15 @@ impl VM {
                         param_count,
                         closure,
                         name: name.to_string(),
+                        module: match self.mod_stack.last() {
+                            Some(v) => v.to_string(),
+                            None => return Err(
+                                VmError {
+                                    msg: "Module stack underflow".to_string(),
+                                    errcode: ErrCode::StackUnderflow
+                                }
+                            )
+                        }
                     }));
                     self.push_to_stack(item);
                 }
@@ -1073,7 +1171,6 @@ fn run(file: String) {
 
                 // Frame location info
                 let source_num = vm.source_select.get(frame.i);
-                println!("{:?}", source_num);
                 let ip_str_val = format!("ins 0x{:04X} ({})", frame.i, frame.i);
                 let ip_str = ip_str_val.dimmed();
 

--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -18,6 +18,7 @@ pub static SUPPORTED_FEATURES: Lazy<Vec<String>> = Lazy::new(|| {
         "attributes".to_string(),
         "indexes".to_string(),
         "imports".to_string(),
+        "runtime_values".to_string()
     ]
 });
 #[derive(Debug, Clone, PartialEq)]

--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -20,11 +20,16 @@ pub static SUPPORTED_FEATURES: Lazy<Vec<String>> = Lazy::new(|| {
         "imports".to_string(),
     ]
 });
+#[derive(Debug, Clone, PartialEq)]
+pub struct Export {
+    pub name: String,
+    pub val: ValueRef,
+}
 #[derive(Debug, Clone)]
 pub struct Env {
     pub values: Vec<Option<ValueRef>>,
     pub parent: Option<Rc<RefCell<Env>>>,
-    pub exports: HashMap<String, ValueRef>,
+    pub exports: HashMap<String, Export>,
 }
 
 impl PartialEq for Env {
@@ -34,8 +39,8 @@ impl PartialEq for Env {
 }
 #[derive(Debug, Clone, PartialEq)]
 pub struct Module {
-    pub exports: HashMap<String, ValueRef>,
-    pub name: Option<String>,
+    pub exports: HashMap<String, Export>,
+    pub name: String,
 }
 #[derive(Debug)]
 pub struct VmError {
@@ -68,6 +73,7 @@ pub enum ValueTag {
     Float = 7,
     Module = 8,
     Array = 9,
+    RuntimeValue = 10,
 }
 
 impl TryFrom<i8> for ValueTag {
@@ -83,6 +89,7 @@ impl TryFrom<i8> for ValueTag {
             7 => Ok(ValueTag::Float),
             8 => Ok(ValueTag::Module),
             9 => Ok(ValueTag::Array),
+            10 => Ok(ValueTag::RuntimeValue),
             _ => Err(VmError {
                 msg: format!("Invalid value tag {}", tag),
                 errcode: ErrCode::InvalidBytecode,
@@ -90,7 +97,17 @@ impl TryFrom<i8> for ValueTag {
         }
     }
 }
-
+#[derive(Debug, Clone)]
+pub enum RuntimeType {
+    Name,
+}
+impl RuntimeType {
+    fn name(&self) -> String {
+        match self {
+            RuntimeType::Name => "name".to_string(),
+        }
+    }
+}
 #[derive(Debug, Clone)]
 pub enum Value {
     Integer(i64),
@@ -101,6 +118,7 @@ pub enum Value {
     Module(Module),
     Array(Rc<RefCell<Vec<ValueRef>>>),
     Null,
+    RuntimeValue(RuntimeType),
 }
 
 impl PartialEq for Value {
@@ -157,11 +175,9 @@ impl Value {
                 OmniFunc::BuiltinMethod { name, .. } => format!("builtin method {}]", name),
             },
             Value::Null => "null".to_string(),
-            Value::Module(m) => match &m.name {
-                Some(v) => format!("[module {}]", v),
-                None => "[module]".to_string(),
-            },
+            Value::Module(m) => format!("[module {}]", m.name),
             Value::Array(_) => "array".to_string(),
+            Value::RuntimeValue(r) => format!("[runtime value '{}']", r.name()),
         }
     }
     pub fn get_tag(&self) -> ValueTag {
@@ -174,6 +190,7 @@ impl Value {
             Value::Module(_) => ValueTag::Module,
             Value::Func(_) => ValueTag::Func,
             Value::Null => ValueTag::Null,
+            Value::RuntimeValue(_) => ValueTag::RuntimeValue,
         }
     }
     pub fn repr(&self) -> String {
@@ -188,11 +205,7 @@ impl Value {
                 OmniFunc::BuiltinMethod { name, .. } => format!("<builtin method {}>", name),
             },
             Value::Module(v) => {
-                if let Some(name) = &v.name {
-                    format!("<module {} ({} exports)>", name, v.exports.len())
-                } else {
-                    format!("<module ({} exports)>", v.exports.len())
-                }
+                format!("<module {} ({} exports)>", v.name, v.exports.len())
             }
             Value::Null => "null".to_string(),
             Value::Array(items_rc) => {
@@ -209,6 +222,7 @@ impl Value {
                 output.push(']');
                 output
             }
+            Value::RuntimeValue(_) => panic!("Illegal value recieved for repr()"), // It should've been converted on PUSH_BUILTIN
         }
     }
 }
@@ -220,6 +234,7 @@ pub enum OmniFunc {
         param_count: usize,
         closure: Rc<RefCell<Env>>,
         name: String,
+        module: String
     },
     Builtin {
         name: String,
@@ -292,23 +307,14 @@ pub fn vm_to_str(args: &[Value]) -> Result<Value, VmError> {
         Value::String(val) => Result::Ok(Value::String(val.to_string())),
         Value::Null => Result::Ok(Value::String("null".to_string())),
         Value::Array(_) => Ok(Value::String(item.repr())),
-        Value::Module(v) => {
-            if v.name.is_some() {
-                Ok(Value::String(format!(
-                    "[module {} with {} exports]",
-                    v.name.as_ref().unwrap(),
-                    v.exports.len()
-                )))
-            } else {
-                Ok(Value::String(format!(
-                    "[module with {} exports]",
-                    v.exports.len()
-                )))
-            }
-        }
+        Value::Module(v) => Ok(Value::String(format!(
+            "[module {} with {} exports]",
+            v.name,
+            v.exports.len()
+        ))),
+        _ => todo!(),
     }
 }
-
 pub fn vm_to_float(args: &[Value]) -> Result<Value, VmError> {
     let [item] = args else {
         return Err(VmError {
@@ -517,13 +523,17 @@ pub fn vmenv() -> Vec<Value> {
         Value::Module(Module {
             exports: HashMap::from([(
                 "hi".to_string(),
-                Rc::new(Value::Func(OmniFunc::Builtin {
-                    name: "hi".to_string(),
-                    func: vm_hi,
-                })),
+                Export {
+                    name: "math".to_string(),
+                    val: Rc::new(Value::Func(OmniFunc::Builtin {
+                        name: "hi".to_string(),
+                        func: vm_hi,
+                    })),
+                },
             )]),
-            name: Some("math".to_string()),
+            name: "math".to_string(),
         }),
+        Value::RuntimeValue(RuntimeType::Name),
     ]
 }
 
@@ -757,7 +767,6 @@ fn gte(a: Value, b: Value) -> Result<Value, VmError> {
         }),
     }
 }
-
 
 fn equal_to(a: Value, b: Value) -> Result<Value, VmError> {
     match (&a, &b) {

--- a/src/omni_compiler/base_env.py
+++ b/src/omni_compiler/base_env.py
@@ -1,4 +1,4 @@
-from omni_compiler.runtime import BuiltinFunction, BuiltinModule, Builtin
+from omni_compiler.runtime import BuiltinFunction, BuiltinModule, Builtin, RuntimeValue
 import copy
 T_INT = 1
 T_STRING = 2
@@ -18,6 +18,7 @@ ASTenv: list[tuple[str, Builtin]] = [
     ('exit', BuiltinFunction('exit', 0, 1)),
     ('len', BuiltinFunction('len', 1, 1)),
     ('math', BuiltinModule([BuiltinFunction('hi', 0, 0)], 'math')),
+    ('_name', RuntimeValue('_name'))
 ]
 Requirement = tuple[str, str, str]  # TODO: make this more readable
 attrs: list[
@@ -50,7 +51,7 @@ attrs: list[
         ),
     ),
     ('insert', 2, 2, (('types.arrays', 'Array', 'Arrays'),)),
-    ('empty', 0, 0, (('types.arrays', 'Array', 'Arrays'),)),
+    ('empty', 0, 0, (('types.arrays', 'Array', 'Arrays'),))
 ]
 
 compiler_env: list[str] = [x[0] for x in ASTenv]

--- a/src/omni_compiler/main.py
+++ b/src/omni_compiler/main.py
@@ -1858,7 +1858,7 @@ class Compiler:
                             for item in params[len(node.args) :]:
                                 if item.option is not None:
                                     yield from self.compile_ins(item.option)
-                        self.emit(node.line, OP_CALL, len(node.args))
+                        self.emit(node.line, OP_CALL, len(params))
                     else:
                         yield self.Warn(
                             'Could not detect how many min and max arguments for function call',

--- a/src/omni_compiler/main.py
+++ b/src/omni_compiler/main.py
@@ -1581,6 +1581,8 @@ class Compiler:
             if idx[1] == 'user':
                 self.emit(node.line, OP_GET_VAR, idx[0], idx[2])  # RETRIEVE idx depth
             else:
+                if node.name == '_name':
+                    yield from self.raise_for_req('runtime_values', 'Runtime Value', 'Runtime Values', node)
                 self.emit(node.line, 'PUSH_BUILTIN', idx[0])
         elif isinstance(node, Assign) and isinstance(node.value, Function):
             res = self.get_var(node.name)

--- a/src/omni_compiler/main.py
+++ b/src/omni_compiler/main.py
@@ -11,62 +11,62 @@ from omni_compiler.runtime import (
     BuiltinFunction,
     ASTNode,
     Program,
-    BuiltinModulePointer,
     Builtin,
 )
 
-ADD = "ADD"  # TODO: refactor this to be better
-INTEGER = "INT"
+ADD = 'ADD'  # TODO: refactor this to be better
+INTEGER = 'INT'
 INT = INTEGER
-IDENTIFIER = "IDENTIFIER"
-ASSIGN = "ASSIGN"
-NEWLINE = "NEWLINE"
-EOF = "EOF"
-DIVIDE = "DIV"
+IDENTIFIER = 'IDENTIFIER'
+ASSIGN = 'ASSIGN'
+NEWLINE = 'NEWLINE'
+EOF = 'EOF'
+DIVIDE = 'DIV'
 DIV = DIVIDE
-MULTIPLY = "MUL"
+MULTIPLY = 'MUL'
 MUL = MULTIPLY
-POWER = "POW"
+POWER = 'POW'
 POW = POWER
-SUBTRACT = "SUB"
+SUBTRACT = 'SUB'
 SUB = SUBTRACT
-RPAREN = "RPAREN"
-LPAREN = "LPAREN"
-STRING = "STRING"
-COMMA = "COMMA"
+RPAREN = 'RPAREN'
+LPAREN = 'LPAREN'
+STRING = 'STRING'
+COMMA = 'COMMA'
 PRECEDENCE = {ADD: 1, SUB: 1, MUL: 2, DIV: 2, POW: 3}
-LBRACE = "LBRACE"
-RBRACE = "RBRACE"
-FUNC = "FUNC"
-RETURN = "RETURN"
-BOOLEAN = "BOOLEAN"
+LBRACE = 'LBRACE'
+RBRACE = 'RBRACE'
+FUNC = 'FUNC'
+RETURN = 'RETURN'
+BOOLEAN = 'BOOLEAN'
 BOOL = BOOLEAN
-GREATER_THAN = "GT"
+GREATER_THAN = 'GT'
 GT = GREATER_THAN
-LESS_THAN = "LT"
+LESS_THAN = 'LT'
 LT = LESS_THAN
-LTE = "LTE"
-GTE = "GTE"
-EQUAL_TO = "EQ"
-NOT_EQUAL_TO = "NEQ"
-IF = "IF"
-ELSE = "ELSE"
-OR = "OR"
-AND = "AND"
-FLOAT = "FLOAT"
-WHILE = "WHILE"
-DOT = "DOT"
-IMPORT = "IMPORT"
-EXPORT = "EXPORT"
-LBRACKET = "LBRACKET"
-RBRACKET = "RBRACKET"
-AT_RATE = "AT_RATE"
-NOT = "NOT"
-PLUS_ASSIGN = "PLUS_ASSIGN"
+LTE = 'LTE'
+GTE = 'GTE'
+EQUAL_TO = 'EQ'
+NOT_EQUAL_TO = 'NEQ'
+IF = 'IF'
+ELSE = 'ELSE'
+OR = 'OR'
+AND = 'AND'
+FLOAT = 'FLOAT'
+WHILE = 'WHILE'
+DOT = 'DOT'
+IMPORT = 'IMPORT'
+EXPORT = 'EXPORT'
+LBRACKET = 'LBRACKET'
+RBRACKET = 'RBRACKET'
+AT_RATE = 'AT_RATE'
+NOT = 'NOT'
+PLUS_ASSIGN = 'PLUS_ASSIGN'
 SUB_ASSIGN = 'SUB_ASSIGN'
 MUL_ASSIGN = 'MUL_ASSIGN'
 DIV_ASSIGN = 'DIV_ASSIGN'
 MOD = 'MOD'
+
 
 @dataclass
 class CompilationException(Exception):
@@ -100,17 +100,17 @@ class TokenizerError(CompilationException):
 
 
 KEYWORDS = {
-    "func": FUNC,
-    "return": RETURN,
-    "if": IF,
-    "else": ELSE,
-    "or": OR,
-    "and": AND,
-    "while": WHILE,
-    "import": IMPORT,
-    "export": EXPORT,
-    "@": AT_RATE,
-    "not": NOT,
+    'func': FUNC,
+    'return': RETURN,
+    'if': IF,
+    'else': ELSE,
+    'or': OR,
+    'and': AND,
+    'while': WHILE,
+    'import': IMPORT,
+    'export': EXPORT,
+    '@': AT_RATE,
+    'not': NOT,
 }
 
 
@@ -147,7 +147,7 @@ class Tokenizer:
             if ch is None:
                 return None
             self.current_idx += 1
-            if ch == "\n":
+            if ch == '\n':
                 self.line += 1
                 self.col = 0
             else:
@@ -162,7 +162,7 @@ class Tokenizer:
     def skip_whitespace(self):
         while True:
             ch = self.get_current_char()
-            if ch is not None and ch.isspace() and ch != "\n":
+            if ch is not None and ch.isspace() and ch != '\n':
                 self.advance()
             else:
                 break
@@ -188,15 +188,14 @@ class Tokenizer:
             )  # End of input
 
         if current_char.isdigit():
-            value = ""
+            value = ''
             fl = False
             while (
                 self.get_current_char() is not None
                 and self.get_current_char().isdigit()  # pyright: ignore[reportOptionalMemberAccess]
-                or self.get_current_char()
-                == "."  # pyright: ignore[reportOptionalMemberAccess]
+                or self.get_current_char() == '.'  # pyright: ignore[reportOptionalMemberAccess]
             ):
-                if self.get_current_char() == ".":
+                if self.get_current_char() == '.':
                     fl = True
                 value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
                 self.advance(1)
@@ -208,126 +207,122 @@ class Tokenizer:
                 return Token(
                     INT, int(value), start_line, start_col, self.line, self.col
                 )
-        elif current_char == "[":
+        elif current_char == '[':
             self.advance(1)
             return Token(LBRACKET, None, start_line, start_col, self.line, self.col)
-        elif current_char == "]":
+        elif current_char == ']':
             self.advance(1)
             return Token(RBRACKET, None, start_line, start_col, self.line, self.col)
-        elif current_char == "@":
+        elif current_char == '@':
             self.advance(1)
             return Token(AT_RATE, None, start_line, start_col, self.line, self.col)
-        elif current_char == "#":
+        elif current_char == '#':
             while (
-                self.get_current_char() is not None and self.get_current_char() != "\n"
+                self.get_current_char() is not None and self.get_current_char() != '\n'
             ):
                 self.advance()
             return self.get_next_token()
-        elif self.check("+="):
+        elif self.check('+='):
             self.advance(2)
             return Token(PLUS_ASSIGN, None, start_line, start_col, self.line, self.col)
-        elif self.check("-="):
+        elif self.check('-='):
             self.advance(2)
             return Token(SUB_ASSIGN, None, start_line, start_col, self.line, self.col)
-        elif self.check("/="):
+        elif self.check('/='):
             self.advance(2)
             return Token(DIV_ASSIGN, None, start_line, start_col, self.line, self.col)
-        elif self.check("*="):
+        elif self.check('*='):
             self.advance(2)
             return Token(MUL_ASSIGN, None, start_line, start_col, self.line, self.col)
-        
-        elif current_char == "+":
+
+        elif current_char == '+':
             self.advance(1)
             return Token(ADD, None, start_line, start_col, self.line, self.col)
-        elif current_char == ".":
+        elif current_char == '.':
             self.advance(1)
             return Token(DOT, None, start_line, start_col, self.line, self.col)
-        elif self.check("true"):
+        elif self.check('true'):
             self.advance(4)
             return Token(BOOL, True, start_line, start_col, self.line, self.col)
-        elif self.check("false"):
+        elif self.check('false'):
             self.advance(5)
             return Token(BOOL, False, start_line, start_col, self.line, self.col)
-        elif self.check("=="):
+        elif self.check('=='):
             self.advance(2)
             return Token(EQUAL_TO, None, start_line, start_col, self.line, self.col)
-        elif current_char == "=":
+        elif current_char == '=':
             self.advance(1)
             return Token(ASSIGN, None, start_line, start_col, self.line, self.col)
-        elif current_char == "-":
+        elif current_char == '-':
             self.advance(1)
             return Token(SUB, None, start_line, start_col, self.line, self.col)
-        elif self.check("**"):
+        elif self.check('**'):
             self.advance(2)
             return Token(POW, None, start_line, start_col, self.line, self.col)
-        elif current_char == "*":
+        elif current_char == '*':
             self.advance(1)
             return Token(MUL, None, start_line, start_col, self.line, self.col)
-        elif self.check("!="):
+        elif self.check('!='):
             self.advance(2)
             return Token(NOT_EQUAL_TO, None, start_line, start_col, self.line, self.col)
-        elif self.check("<="):
+        elif self.check('<='):
             self.advance(2)
             return Token(LTE, None, start_line, start_col, self.line, self.col)
-        elif self.check(">="):
+        elif self.check('>='):
             self.advance(2)
             return Token(GTE, None, start_line, start_col, self.line, self.col)
-        elif current_char == "\n":
+        elif current_char == '\n':
             self.advance(1)
             return Token(NEWLINE, None, start_line, start_col, self.line, self.col)
-        elif current_char == "(":
+        elif current_char == '(':
             self.advance(1)
             return Token(LPAREN, None, start_line, start_col, self.line, self.col)
-        elif current_char == ")":
+        elif current_char == ')':
             self.advance(1)
             return Token(RPAREN, None, start_line, start_col, self.line, self.col)
-        elif current_char == "{":
+        elif current_char == '{':
             self.advance(1)
             return Token(LBRACE, None, start_line, start_col, self.line, self.col)
-        elif current_char == "}":
+        elif current_char == '}':
             self.advance(1)
             return Token(RBRACE, None, start_line, start_col, self.line, self.col)
-        elif current_char == "/":
+        elif current_char == '/':
             self.advance(1)
             return Token(DIV, None, start_line, start_col, self.line, self.col)
-        elif current_char == ",":
+        elif current_char == ',':
             self.advance(1)
             return Token(COMMA, None, start_line, start_col, self.line, self.col)
-        elif current_char == "<":
+        elif current_char == '<':
             self.advance(1)
             return Token(LESS_THAN, None, start_line, start_col, self.line, self.col)
         elif current_char == '%':
             self.advance(1)
             return Token(MOD, None, start_line, start_col, self.line, self.col)
-        elif current_char == ">":
+        elif current_char == '>':
             self.advance(1)
             return Token(GREATER_THAN, None, start_line, start_col, self.line, self.col)
         elif current_char == '"':
             self.advance(1)
-            value = ""
+            value = ''
             while (
                 self.get_current_char() is not None and self.get_current_char() != '"'
             ):
-                if self.get_current_char() == "\\":
+                if self.get_current_char() == '\\':
                     self.advance()
                     match self.get_current_char():
-                        case "n":
-                            value += "\n"
-                        case "t":
-                            value += "\t"
+                        case 'n':
+                            value += '\n'
+                        case 't':
+                            value += '\t'
                         case _:
-                            value += (
-                                self.get_current_char()
-                            )  # pyright: ignore[reportOperatorIssue]
+                            value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
                 else:
-                    value += (
-                        self.get_current_char()
-                    )  # pyright: ignore[reportOperatorIssue]
+                    value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
                 self.advance()
             if self.get_current_char() != '"':
                 raise TokenizerError(
                     1,
-                    "Unterminated string literal",
+                    'Unterminated string literal',
                     self.line,
                     self.col,
                     self.line,
@@ -337,30 +332,26 @@ class Tokenizer:
             return Token(STRING, value, start_line, start_col, self.line, self.col)
         elif current_char == "'":
             self.advance(1)
-            value = ""
+            value = ''
             while (
                 self.get_current_char() is not None and self.get_current_char() != "'"
             ):
-                if self.get_current_char() == "\\":
+                if self.get_current_char() == '\\':
                     self.advance()
                     match self.get_current_char():
-                        case "n":
-                            value += "\n"
-                        case "t":
-                            value += "\t"
+                        case 'n':
+                            value += '\n'
+                        case 't':
+                            value += '\t'
                         case _:
-                            value += (
-                                self.get_current_char()
-                            )  # pyright: ignore[reportOperatorIssue]
+                            value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
                 else:
-                    value += (
-                        self.get_current_char()
-                    )  # pyright: ignore[reportOperatorIssue]
+                    value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
                 self.advance()
             if self.get_current_char() != "'":
                 raise TokenizerError(
                     1,
-                    "Unterminated string literal",
+                    'Unterminated string literal',
                     self.line,
                     self.col,
                     self.line,
@@ -369,17 +360,15 @@ class Tokenizer:
             self.advance()
             return Token(STRING, value, start_line, start_col, self.line, self.col)
 
-        elif current_char.isalpha() or current_char == "_":
+        elif current_char.isalpha() or current_char == '_':
             to_return = current_char
             self.advance()
             while (
                 self.get_current_char() is not None
                 and self.get_current_char().isalnum()  # pyright: ignore[reportOptionalMemberAccess]
-                or self.get_current_char() == "_"
+                or self.get_current_char() == '_'
             ):  # pyright: ignore[reportOptionalMemberAccess]
-                to_return += (
-                    self.get_current_char()
-                )  # pyright: ignore[reportOperatorIssue]
+                to_return += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
                 self.advance()
             tok_type = KEYWORDS.get(to_return, IDENTIFIER)
             return Token(
@@ -413,43 +402,43 @@ class OmniType:
 @dataclass
 class OmniStr(OmniType):
     def __init__(self):
-        self.display = "str"
+        self.display = 'str'
 
 
 @dataclass
 class OmniFloat(OmniType):
     def __init__(self):
-        self.display = "float"
+        self.display = 'float'
 
 
 @dataclass
 class OmniInt(OmniType):
     def __init__(self):
-        self.display = "int"
+        self.display = 'int'
 
 
 @dataclass
 class OmniFunc(OmniType):
     def __init__(self):
-        self.display = "func"
+        self.display = 'func'
 
 
 @dataclass
 class OmniModule(OmniType):
     def __init__(self):
-        self.display = "mod"
+        self.display = 'mod'
 
 
 @dataclass
 class OmniArray(OmniType):
     def __init__(self):
-        self.display = "array"
+        self.display = 'array'
 
 
 @dataclass
 class OmniNull(OmniType):
     def __init__(self):
-        self.display = "null"
+        self.display = 'null'
 
 
 class Parser:
@@ -471,7 +460,7 @@ class Parser:
         if self.current_token.type != token_type:
             raise ParserError(
                 3,
-                f"Expected {token_type}, got {self.current_token.type}",
+                f'Expected {token_type}, got {self.current_token.type}',
                 self.current_token.line,
                 self.current_token.col,
                 self.current_token.end_line,
@@ -764,7 +753,7 @@ class Parser:
         if out is None:
             raise ParserError(
                 3,
-                "Expected a statement",
+                'Expected a statement',
                 self.current_token.line,
                 self.current_token.col,
                 self.current_token.end_line,
@@ -773,7 +762,7 @@ class Parser:
         if not isinstance(out, Assign):
             raise ParserError(
                 5,
-                "Cannot export anything other than an assignment or function",
+                'Cannot export anything other than an assignment or function',
                 out.line,
                 out.col,
                 self.current_token.end_line,
@@ -797,22 +786,22 @@ class Parser:
             return None
         elif self.current_token.type == AT_RATE:
             self.eat(AT_RATE)
-            if self.current_token.value == "require":
+            if self.current_token.value == 'require':
                 ln = self.current_token.line
                 col = self.current_token.col
                 self.eat(IDENTIFIER)
                 reqs = []
-                req = ""
+                req = ''
 
                 req += self.eat(IDENTIFIER).value
 
                 while self.current_token.type == DOT:
-                    req += "."
+                    req += '.'
                     self.eat(DOT)
                     req += self.eat(IDENTIFIER).value
 
                 reqs.append(req)
-                req = ""
+                req = ''
                 while self.current_token.type == COMMA:
                     if self.current_token.type == EOF:
                         self.incomplete_input()
@@ -820,11 +809,11 @@ class Parser:
                     self.eat(COMMA)
                     req += self.eat(IDENTIFIER).value
                     while self.current_token.type == DOT:
-                        req += "."
+                        req += '.'
                         self.eat(DOT)
                         req += self.eat(IDENTIFIER).value
                     reqs.append(req)
-                    req = ""
+                    req = ''
                 if self.current_token.type == LBRACE:
                     blk = self.block()
                     else_block: Block | None = None
@@ -874,7 +863,12 @@ class Parser:
                 self.eat(ASSIGN)
                 value = self.expr()
                 return Assign(ln, col, value.end_line, value.end_col, name, value)
-            elif next_tok and next_tok.type in (PLUS_ASSIGN, DIV_ASSIGN, MUL_ASSIGN, SUB_ASSIGN):
+            elif next_tok and next_tok.type in (
+                PLUS_ASSIGN,
+                DIV_ASSIGN,
+                MUL_ASSIGN,
+                SUB_ASSIGN,
+            ):
                 ln = self.current_token.line
                 col = self.current_token.col
                 name = self.eat(IDENTIFIER).value
@@ -889,9 +883,16 @@ class Parser:
                 elif op_type == DIV_ASSIGN:
                     op = DIV
                 else:
-                    raise ParserError(13, f'(internal) Expected token to be of type PLUS_ASSIGN, DIV_ASSIGN, MUL_ASSIGN, or SUB_ASSIGN, got {op_type}.', self.current_token.line, self.current_token.col, self.current_token.end_line, self.current_token.end_col)
+                    raise ParserError(
+                        13,
+                        f'(internal) Expected token to be of type PLUS_ASSIGN, DIV_ASSIGN, MUL_ASSIGN, or SUB_ASSIGN, got {op_type}.',
+                        self.current_token.line,
+                        self.current_token.col,
+                        self.current_token.end_line,
+                        self.current_token.end_col,
+                    )
                 value = self.expr()
-                
+
                 return Assign(
                     ln,
                     col,
@@ -976,7 +977,7 @@ class Parser:
             elif optional:
                 raise ParserError(
                     7,
-                    "Cannot have a non-optional argument after an optional argument",
+                    'Cannot have a non-optional argument after an optional argument',
                     self.current_token.line,
                     self.current_token.col,
                     self.current_token.end_line,
@@ -1002,7 +1003,7 @@ class Parser:
                 elif optional:
                     raise ParserError(
                         7,
-                        "Cannot have a non-optional argument after an optional argument",
+                        'Cannot have a non-optional argument after an optional argument',
                         self.current_token.line,
                         self.current_token.col,
                         self.current_token.end_line,
@@ -1031,7 +1032,7 @@ class Parser:
         if self.current_token.type != EOF:
             raise ParserError(
                 3,
-                f"Unexpected token of type {self.current_token.type}: {self.current_token.value}",
+                f'Unexpected token of type {self.current_token.type}: {self.current_token.value}',
                 self.current_token.line,
                 self.current_token.col,
                 self.current_token.end_line,
@@ -1149,33 +1150,28 @@ class BinOp(ASTNode):
 
 @dataclass
 class Variable(ASTNode):
-
     name: str
 
 
 @dataclass
 class FunctionParameter(ASTNode):
-
     name: str
     option: None | ASTNode
 
 
 @dataclass
 class Assign(ASTNode):
-
     name: str
     value: ASTNode
 
 
 @dataclass
 class String(ASTNode):
-
     value: str
 
 
 @dataclass
 class Return(ASTNode):
-
     value: ASTNode | None
 
 
@@ -1194,14 +1190,12 @@ class If(ASTNode):
 
 @dataclass
 class While(ASTNode):
-
     expr: ASTNode
     body: Block
 
 
 @dataclass
 class Export(ASTNode):
-
     lhs: ASTNode
     name: str
 
@@ -1210,9 +1204,9 @@ class NOP(ASTNode):
     pass
 
 
-OP_SET_VAR = "STORE"
-OP_GET_VAR = "RETRIEVE"
-OP_PUSH_CONST = "PUSH_CONST"
+OP_SET_VAR = 'STORE'
+OP_GET_VAR = 'RETRIEVE'
+OP_PUSH_CONST = 'PUSH_CONST'
 OP_ADD = ADD
 OP_SUB = SUB
 OP_MUL = MUL
@@ -1226,8 +1220,8 @@ OP_EQUAL_TO = EQUAL_TO
 OP_NOT_EQUAL_TO = NOT_EQUAL_TO
 OP_OR = OR
 OP_AND = AND
-OP_CALL = "CALL"
-NEG = "NEG"
+OP_CALL = 'CALL'
+NEG = 'NEG'
 OP_NEG = NEG
 OP_MOD = MOD
 OP_NOT = NOT
@@ -1247,10 +1241,10 @@ OPCODE_MAP = {
     AND: OP_AND,
     NEG: OP_NEG,
     NOT: OP_NOT,
-    MOD: OP_MOD
+    MOD: OP_MOD,
 }
-BUILTIN = "BUILTIN"
-NULL = "NULL"
+BUILTIN = 'BUILTIN'
+NULL = 'NULL'
 
 
 class Compiler:
@@ -1278,12 +1272,12 @@ class Compiler:
         self.filepath = filepath
         self.exports = []
         self.source_info: list[int] = []
-        self.req_stack: list[Compiler.RequirementGroup] = (
-            []
-        )  # LIFO stack for nested @require statements
-        self.req_stack_not_allowed: list[Compiler.RequirementGroup] = (
-            []
-        )  # for errors when using a feature where it isn't allowed, like the else branch of an @require statement
+        self.req_stack: list[
+            Compiler.RequirementGroup
+        ] = []  # LIFO stack for nested @require statements
+        self.req_stack_not_allowed: list[
+            Compiler.RequirementGroup
+        ] = []  # for errors when using a feature where it isn't allowed, like the else branch of an @require statement
         self.attrs: list[
             tuple[str, int, int, tuple[tuple[str, str, str], ...] | None]
         ] = attrs
@@ -1379,13 +1373,13 @@ class Compiler:
 
     def get_var(
         self, name
-    ) -> tuple[int, Literal["user", "builtin"], int | None] | None:
+    ) -> tuple[int, Literal['user', 'builtin'], int | None] | None:
         for depth, scope in enumerate(reversed(self.scopes)):
             if name in scope.var_map:
-                return scope.var_map[name].idx, "user", depth
+                return scope.var_map[name].idx, 'user', depth
         for i, item in enumerate(self.passed_env):
             if item == name:
-                return i, "builtin", None
+                return i, 'builtin', None
         return None
 
     def get_var_obj(
@@ -1412,20 +1406,20 @@ class Compiler:
     def compile(
         self,
         program: Program,
-        features: Collection[Literal["source"] | Literal["line"]] = [],
+        features: Collection[Literal['source'] | Literal['line']] = [],
         input_source: str | None = None,
     ) -> Generator[Warn | ModuleRequest, ModuleReceived | None, list[str]]:
-        if input_source is None and "source" in features:
+        if input_source is None and 'source' in features:
             raise CompilerError(
                 8,
-                "Compiler needs input source to compile with source info.",
+                'Compiler needs input source to compile with source info.',
                 None,
                 None,
                 None,
                 None,
                 self.mod_stack[-1].fp,
             )
-        if "source" in features:
+        if 'source' in features:
             self.sources[self.filepath] = (  # pyright: ignore[reportArgumentType]
                 input_source
             )
@@ -1436,38 +1430,38 @@ class Compiler:
             yield from self.compile_ins(node)
             # drop any value produced by the statement so that subsequent
             # instructions start with a clean stack
-            self.emit(node.line, "POP")
-        self.emit(0, "NOP")
+            self.emit(node.line, 'POP')
+        self.emit(0, 'NOP')
         output = []
-        output.append(".version")
-        output.append("ENV 1")
-        output.append("ISA 1")
+        output.append('.version')
+        output.append('ENV 1')
+        output.append('ISA 1')
         if len(self.reqs) > 0:
-            output.append(".reqs " + " ".join([str(x) for x in self.reqs]))
+            output.append('.reqs ' + ' '.join([str(x) for x in self.reqs]))
 
-        output.append(f".frame {self.scopes[0].next_local}")
+        output.append(f'.frame {self.scopes[0].next_local}')
 
-        output.append(".const")
+        output.append('.const')
         for const in self.constants:
             output.append(
                 f'{const[0]};{str(const[1]).replace("\n", "\\n").replace(";", "\\;")};'
             )
-        output.append(".code")
+        output.append('.code')
         for instr in self.code:
-            output.append(" ".join(map(str, instr)))
-        if "line" in features:
-            output.append(".line")
+            output.append(' '.join(map(str, instr)))
+        if 'line' in features:
+            output.append('.line')
             for line in self.lines:
                 output.append(line)
-        if "source" in features:
-            output.append(".source_select")
+        if 'source' in features:
+            output.append('.source_select')
             output += self.source_info
             for fp, source_content in self.sources.items():
                 idx = len(output)
-                output.append("")
+                output.append('')
                 output += source_content.splitlines()
-                output[idx] = f".source {len(output)} {fp}"
-        output.append("")  # to prevent errors if a source's end is the end of the file
+                output[idx] = f'.source {len(output)} {fp}'
+        output.append('')  # to prevent errors if a source's end is the end of the file
         return output
 
     def raise_for_req(
@@ -1497,7 +1491,7 @@ class Compiler:
             if illegal:
                 if unsure:
                     yield self.Warn(
-                        f"CRITICAL: This may need the `{req}` requirement, and is in an illegal zone. Perhaps add `@require {req}` to the top of your program?",  # TODO: warning priorities
+                        f'CRITICAL: This may need the `{req}` requirement, and is in an illegal zone. Perhaps add `@require {req}` to the top of your program?',  # TODO: warning priorities
                         ln,
                         col,
                         end_line,
@@ -1508,7 +1502,7 @@ class Compiler:
                 else:
                     raise CompilerError(
                         14,
-                        f"Attempted using a(n) {name} when it requires `{req}` in an illegal area",
+                        f'Attempted using a(n) {name} when it requires `{req}` in an illegal area',
                         ln,
                         col,
                         end_line,
@@ -1518,7 +1512,7 @@ class Compiler:
             else:
                 if unsure:
                     yield self.Warn(
-                        f"This may need the `{req}` requirement. Perhaps add `@require {req}` to the top of your program?",
+                        f'This may need the `{req}` requirement. Perhaps add `@require {req}` to the top of your program?',
                         ln,
                         col,
                         end_line,
@@ -1529,7 +1523,7 @@ class Compiler:
                 else:
                     self.reqs.append(req)
                     yield self.Warn(
-                        f"{second_name} implicitly adds the `{req}` requirement. Perhaps add `@require {req}` to the top of your program to make it explicit?",
+                        f'{second_name} implicitly adds the `{req}` requirement. Perhaps add `@require {req}` to the top of your program to make it explicit?',
                         ln,
                         col,
                         end_line,
@@ -1556,7 +1550,7 @@ class Compiler:
             consts: list[int] = []
             for item in node.reqs:
                 consts.append(self.add_constant((2, item)))
-            idx = self.emit(node.line, "REQUIRE", *consts, None)
+            idx = self.emit(node.line, 'REQUIRE', *consts, None)
             self.req_stack.append(
                 self.RequirementGroup(node.reqs)
             )  # create a new stack so later on warnings wont happen
@@ -1564,37 +1558,37 @@ class Compiler:
             self.req_stack.pop()  # remove the stack after the statement
             if node.else_block is not None:
                 self.req_stack_not_allowed.append(self.RequirementGroup(node.reqs))
-                jmp = self.emit(node.line, "JMP", None)
-                self.code[idx] = ("REQUIRE", *consts, len(self.code))
+                jmp = self.emit(node.line, 'JMP', None)
+                self.code[idx] = ('REQUIRE', *consts, len(self.code))
                 yield from self.compile_ins(node.else_block)
                 self.req_stack_not_allowed.pop()
-                self.code[jmp] = ("JMP", len(self.code))
+                self.code[jmp] = ('JMP', len(self.code))
             else:
-                self.code[idx] = ("REQUIRE", *consts, len(self.code))
+                self.code[idx] = ('REQUIRE', *consts, len(self.code))
         elif isinstance(node, Variable):
             # if node.name in self.scopes[-1].var_map:
             idx = self.get_var(node.name)
             if idx is None:
                 raise CompilerError(
                     9,
-                    f"Variable {node.name} not declared",
+                    f'Variable {node.name} not declared',
                     node.line,
                     node.col,
                     node.end_line,
                     node.end_col,
                     self.mod_stack[-1].fp,
                 )
-            if idx[1] == "user":
+            if idx[1] == 'user':
                 self.emit(node.line, OP_GET_VAR, idx[0], idx[2])  # RETRIEVE idx depth
             else:
-                self.emit(node.line, "PUSH_BUILTIN", idx[0])
+                self.emit(node.line, 'PUSH_BUILTIN', idx[0])
         elif isinstance(node, Assign) and isinstance(node.value, Function):
             res = self.get_var(node.name)
             if res is None:
                 idx = self.declare_local(node.name, node.value)
                 yield from self.compile_ins(node.value, node.name)
                 if len(other) > 0 and other[0]:
-                    self.emit(node.line, "DUP")
+                    self.emit(node.line, 'DUP')
                 self.emit(node.line, OP_SET_VAR, idx, 0)
                 return idx, 0
             else:
@@ -1603,13 +1597,13 @@ class Compiler:
 
                 idx = self.declare_local(node.name, node.value)
                 if len(other) > 0 and other[0]:
-                    self.emit(node.line, "DUP")
+                    self.emit(node.line, 'DUP')
                 if depth is None:
                     depth = 0
                 self.emit(node.line, OP_SET_VAR, idx, depth)
 
                 yield self.Warn(
-                    f"Reassignment to a function attempted for {node.name}(). This is usually not recommended",
+                    f'Reassignment to a function attempted for {node.name}(). This is usually not recommended',
                     node.line,
                     node.col,
                     node.end_line,
@@ -1624,30 +1618,17 @@ class Compiler:
                 yield from self.compile_ins(node.value)
                 idx = self.declare_local(node.name, node.value)
                 if len(other) > 0 and other[0]:
-                    self.emit(node.line, "DUP")
+                    self.emit(node.line, 'DUP')
                 self.emit(node.line, OP_SET_VAR, idx, 0)
             else:
                 idx, _, depth = res
                 yield from self.compile_ins(node.value)
                 idx = self.declare_local(node.name, node.value)
                 if len(other) > 0 and other[0]:
-                    self.emit(node.line, "DUP")
+                    self.emit(node.line, 'DUP')
                 if depth is None:
                     depth = 0
                 self.emit(node.line, OP_SET_VAR, idx, depth)
-        elif isinstance(node, BuiltinModulePointer):
-            ref = self.ASTenv[node.idx]
-            if ref[0] in self.modules:
-                raise CompilerError(
-                    10,
-                    f"Module {ref[0]} already imported.",
-                    node.line,
-                    node.col,
-                    node.end_line,
-                    node.end_col,
-                    self.mod_stack[-1].fp,
-                )
-            self.emit(-1, "PUSH_BUILTIN", node.idx)
         elif isinstance(node, BinOp):
             yield from self.compile_ins(node.left)
             yield from self.compile_ins(node.right)
@@ -1659,7 +1640,7 @@ class Compiler:
             for statement in node.statements:
                 yield from self.compile_ins(statement)
         elif isinstance(node, Bool):
-            idx = self.add_constant([T_BOOL, "true" if node.value else "false"])
+            idx = self.add_constant([T_BOOL, 'true' if node.value else 'false'])
             self.emit(node.line, OP_PUSH_CONST, idx)
         elif isinstance(node, Call):
             # compile the expression that identifies the callable (variable, attribute, etc.)
@@ -1667,9 +1648,7 @@ class Compiler:
             exported = None
             # validate argument count depending on what kind of call this is
             if isinstance(node.func, Variable):
-                itm = self.get_var_obj(
-                    node.func.name
-                )[  # pyright: ignore[reportOptionalSubscript]
+                itm = self.get_var_obj(node.func.name)[  # pyright: ignore[reportOptionalSubscript]
                     0
                 ]
                 if isinstance(itm, self.ScopeItem):
@@ -1683,7 +1662,7 @@ class Compiler:
                             if not len(req) == len(params):
                                 raise CompilerError(
                                     11,
-                                    f"Expected {len(req)} to {len(params)} arguments, got {len(node.args)}",
+                                    f'Expected {len(req)} to {len(params)} arguments, got {len(node.args)}',
                                     node.line,
                                     node.col,
                                     node.end_line,
@@ -1693,7 +1672,7 @@ class Compiler:
                             else:
                                 raise CompilerError(
                                     11,
-                                    f"Expected exactly {len(req)} arguments, got {len(node.args)}",
+                                    f'Expected exactly {len(req)} arguments, got {len(node.args)}',
                                     node.line,
                                     node.col,
                                     node.end_line,
@@ -1707,7 +1686,7 @@ class Compiler:
                         if not (itm.value.req_args <= len(node.args)):
                             raise CompilerError(
                                 11,
-                                f"Expected at least {itm.value.req_args} args, got {len(node.args)}",
+                                f'Expected at least {itm.value.req_args} args, got {len(node.args)}',
                                 node.line,
                                 node.col,
                                 node.end_line,
@@ -1721,7 +1700,7 @@ class Compiler:
                             if itm.value.req_args == itm.value.max_args:
                                 raise CompilerError(
                                     11,
-                                    f"Expected exactly {itm.value.req_args} args, got {len(node.args)}",
+                                    f'Expected exactly {itm.value.req_args} args, got {len(node.args)}',
                                     node.line,
                                     node.col,
                                     node.end_line,
@@ -1731,7 +1710,7 @@ class Compiler:
                             else:
                                 raise CompilerError(
                                     11,
-                                    f"Expected {itm.value.req_args} to {itm.value.max_args} args, got {len(node.args)}",
+                                    f'Expected {itm.value.req_args} to {itm.value.max_args} args, got {len(node.args)}',
                                     node.line,
                                     node.col,
                                     node.end_line,
@@ -1759,7 +1738,7 @@ class Compiler:
                     if atr_itm is None:
                         raise CompilerError(
                             12,
-                            f"No attribute `{node.func.rhs}` found",
+                            f'No attribute `{node.func.rhs}` found',
                             node.line,
                             node.col,
                             node.end_line,
@@ -1767,12 +1746,8 @@ class Compiler:
                             self.mod_stack[-1].fp,
                         )
                 else:
-                    if isinstance(
-                        exported.item, Function
-                    ):  # pyright: ignore[reportPossiblyUnboundVariable]
-                        params = (
-                            exported.item.params
-                        )  # pyright: ignore[reportPossiblyUnboundVariable]
+                    if isinstance(exported.item, Function):  # pyright: ignore[reportPossiblyUnboundVariable]
+                        params = exported.item.params  # pyright: ignore[reportPossiblyUnboundVariable]
                         req: list[FunctionParameter] = []
                         for item in params:
                             if item.option is None:
@@ -1781,7 +1756,7 @@ class Compiler:
                             if not len(req) == len(params):
                                 raise CompilerError(
                                     11,
-                                    f"Expected {len(req)} to {len(params)} arguments, got {len(node.args)}",
+                                    f'Expected {len(req)} to {len(params)} arguments, got {len(node.args)}',
                                     node.line,
                                     node.col,
                                     node.end_line,
@@ -1791,7 +1766,7 @@ class Compiler:
                             else:
                                 raise CompilerError(
                                     11,
-                                    f"Expected exactly {len(req)} arguments, got {len(node.args)}",
+                                    f'Expected exactly {len(req)} arguments, got {len(node.args)}',
                                     node.line,
                                     node.col,
                                     node.end_line,
@@ -1815,7 +1790,7 @@ class Compiler:
                         if min_args == max_args:
                             raise CompilerError(
                                 11,
-                                f"Expected exactly {min_args} args, got {len(node.args)}",
+                                f'Expected exactly {min_args} args, got {len(node.args)}',
                                 node.line,
                                 node.col,
                                 node.end_line,
@@ -1825,7 +1800,7 @@ class Compiler:
                         else:
                             raise CompilerError(
                                 11,
-                                f"Expected {min_args} to {max_args} args, got {len(node.args)}",
+                                f'Expected {min_args} to {max_args} args, got {len(node.args)}',
                                 node.line,
                                 node.col,
                                 node.end_line,
@@ -1844,7 +1819,7 @@ class Compiler:
                             if min_args == max_args:
                                 raise CompilerError(
                                     11,
-                                    f"Expected exactly {min_args} args, got {len(node.args)}",
+                                    f'Expected exactly {min_args} args, got {len(node.args)}',
                                     node.line,
                                     node.col,
                                     node.end_line,
@@ -1854,7 +1829,7 @@ class Compiler:
                             else:
                                 raise CompilerError(
                                     11,
-                                    f"Expected {min_args} to {max_args} args, got {len(node.args)}",
+                                    f'Expected {min_args} to {max_args} args, got {len(node.args)}',
                                     node.line,
                                     node.col,
                                     node.end_line,
@@ -1871,26 +1846,28 @@ class Compiler:
 
             # emit the call instruction appropriate for the kind of callable
             if isinstance(node.func, Variable):
-                itm = self.get_var_obj(
-                    node.func.name
-                )[  # pyright: ignore[reportOptionalSubscript]
+                itm = self.get_var_obj(node.func.name)[  # pyright: ignore[reportOptionalSubscript]
                     0
                 ]
                 if isinstance(itm, self.ScopeItem):
                     if isinstance(itm.value, Function):
                         params = itm.value.params
-                        req: list[FunctionParameter] = []
-                        for item in params:
-                            if item.option is not None:
-                                req.append(item)
-                        if len(req) >= len(node.args):
-                            for item in params[len(req) :]:
-                                yield from self.compile_ins(
-                                    item.option  # pyright: ignore[reportArgumentType]
-                                )
-                        self.emit(node.line, OP_CALL, len(params))
+                        if len(params) > len(node.args):
+                            for item in params[len(node.args) :]:
+                                if item.option is not None:
+                                    yield from self.compile_ins(item.option)
+                        self.emit(node.line, OP_CALL, len(node.args))
                     else:
-                        raise  # should not happen
+                        yield self.Warn(
+                            'Could not detect how many min and max arguments for function call',
+                            node.line,
+                            node.col,
+                            node.end_line,
+                            node.end_col,
+                            self.mod_stack[-1].fp,
+                            self,
+                        )
+                        self.emit(node.line, OP_CALL, len(node.args))
                 elif isinstance(itm, self.BuiltinScopeItem):
                     self.emit(node.line, OP_CALL, len(node.args))
                 else:
@@ -1912,31 +1889,31 @@ class Compiler:
                 raise NotImplementedError  # falling back for future call types
         elif isinstance(node, While):
             yield from self.compile_ins(node.expr)
-            jmp = self.emit(node.line, "JMPIFF", None)
+            jmp = self.emit(node.line, 'JMPIFF', None)
             yield from self.compile_ins(node.body)
             yield from self.compile_ins(node.expr)
-            self.emit(node.line, "JMPIF", jmp + 1)
-            self.code[jmp] = ("JMPIFF", len(self.code))
+            self.emit(node.line, 'JMPIF', jmp + 1)
+            self.code[jmp] = ('JMPIFF', len(self.code))
         elif isinstance(node, If):
             yield from self.compile_ins(node.expr)
-            jmp = self.emit(node.line, "JMPIFF", None)
+            jmp = self.emit(node.line, 'JMPIFF', None)
             yield from self.compile_ins(node.body)
             if node.else_body:
-                jmp2 = self.emit(node.line, "JMP", None)
-                self.code[jmp] = ("JMPIFF", len(self.code))
+                jmp2 = self.emit(node.line, 'JMP', None)
+                self.code[jmp] = ('JMPIFF', len(self.code))
                 yield from self.compile_ins(node.else_body)
-                self.code[jmp2] = ("JMP", len(self.code))
+                self.code[jmp2] = ('JMP', len(self.code))
             else:
-                self.code[jmp] = ("JMPIFF", len(self.code))
+                self.code[jmp] = ('JMPIFF', len(self.code))
         elif isinstance(node, Array):
-            yield from self.raise_for_req("types.arrays", "Array", "Arrays", node)
+            yield from self.raise_for_req('types.arrays', 'Array', 'Arrays', node)
             for item in reversed(node.items):
                 yield from self.compile_ins(item)
-            self.emit(node.line, "BUILD_ARRAY", len(node.items))
+            self.emit(node.line, 'BUILD_ARRAY', len(node.items))
         elif isinstance(node, NOP):
-            self.emit(0, "NOP")
+            self.emit(0, 'NOP')
         elif isinstance(node, Function):
-            jmp = self.emit(node.line, "JMP", None)
+            jmp = self.emit(node.line, 'JMP', None)
             fn_entry = len(self.code)
             self.enter_scope({})
             for param in node.params:
@@ -1944,18 +1921,18 @@ class Compiler:
             yield from self.compile_ins(node.body)
 
             self.emit(
-                node.line, "PUSH_CONST", self.add_constant((base_env.T_NULL, None))
+                node.line, 'PUSH_CONST', self.add_constant((base_env.T_NULL, None))
             )
-            self.emit(node.line, "RET")
+            self.emit(node.line, 'RET')
 
             local_count = self.scopes[-1].next_local
             self.exit_scope()
-            self.code[jmp] = ("JMP", len(self.code))
+            self.code[jmp] = ('JMP', len(self.code))
             if len(other) >= 1:
                 idx = self.add_constant([T_STRING, other[0]])
                 self.emit(
                     node.line,
-                    "MAKE_FUNCTION",
+                    'MAKE_FUNCTION',
                     fn_entry,
                     local_count,
                     len(node.params),
@@ -1964,7 +1941,7 @@ class Compiler:
             else:
                 raise CompilerError(
                     13,
-                    "(internal) Expected array `other` to have at least 1 value, found 0. This error should not be raised under any circumstance, please report at https://github.com/DELOLCAT/OmniScript.",
+                    '(internal) Expected array `other` to have at least 1 value, found 0. This error should not be raised under any circumstance, please report at https://github.com/DELOLCAT/OmniScript.',
                     None,
                     None,
                     None,
@@ -1973,11 +1950,11 @@ class Compiler:
                 )
         elif isinstance(node, Return):
             if node.value is None:
-                idx = self.add_constant((T_NULL, ""))
+                idx = self.add_constant((T_NULL, ''))
                 self.emit(node.line, OP_PUSH_CONST, idx)
                 return
             yield from self.compile_ins(node.value)
-            self.emit(node.line, "RET")
+            self.emit(node.line, 'RET')
         elif isinstance(node, Export):
             yield from self.compile_ins(
                 Assign(
@@ -1992,9 +1969,9 @@ class Compiler:
             )
             idx = self.add_constant((T_STRING, node.name))
             self.mod_stack[-1].exports.append(self.ExportItem(node.name, node.lhs))
-            self.emit(node.line, "EXPORT", idx)
+            self.emit(node.line, 'EXPORT', idx)
         elif isinstance(node, Attribute):
-            yield from self.raise_for_req("attributes", "Attribute", "Attributes", node)
+            yield from self.raise_for_req('attributes', 'Attribute', 'Attributes', node)
             broken = False
             if isinstance(node.lhs, Variable):
                 itm = self.get_var_obj(node.lhs.name)
@@ -2012,7 +1989,7 @@ class Compiler:
                 if not broken:
                     raise CompilerError(
                         12,
-                        f"Could not find attribute {node.rhs}",
+                        f'Could not find attribute {node.rhs}',
                         node.line,
                         node.col,
                         node.end_line,
@@ -2021,20 +1998,21 @@ class Compiler:
                     )
             yield from self.compile_ins(node.lhs)
             idx = self.add_constant((T_STRING, node.rhs))
-            self.emit(node.line, "GETATTR", idx)
+            self.emit(node.line, 'GETATTR', idx)
         elif isinstance(node, GetIndex):
-            yield from self.raise_for_req("indexes", "Index", "Indexing", node)
+            yield from self.raise_for_req('indexes', 'Index', 'Indexing', node)
             yield from self.compile_ins(node.idx)
             yield from self.compile_ins(node.item)
-            self.emit(node.line, "GET_ITEM")
+            self.emit(node.line, 'GET_ITEM')
         elif isinstance(node, Import):
-            yield from self.raise_for_req("imports", "Import", "Importing", node)
+            yield from self.raise_for_req('imports', 'Import', 'Importing', node)
+            self.emit(node.line, 'ENTER_MODULE', self.add_constant((T_STRING, node.mod)))
             module = yield self.ModuleRequest(
                 node.mod, node.line, node.col, node.end_line, node.end_col
             )
 
             if module is None:
-                raise TypeError("`module` is None")
+                raise TypeError('`module` is None')
             self.mod_stack.append(self.Module(0, 0, 0, 0, [], module.filepath))
             self.modules.append(node.mod)
             self.enter_scope()
@@ -2042,7 +2020,8 @@ class Compiler:
             for statement in module.program.statements:
                 yield from self.compile_ins(statement)
             self.exit_scope()
-            self.emit(node.line, "MAKE_MODULE")
+            idx = self.add_constant((T_STRING, node.mod))
+            self.emit(node.line, 'MAKE_MODULE', idx)
             md = self.mod_stack.pop()
             self.scopes[0].next_local += 1  # TODO: make this better
             yield from self.compile_ins(
@@ -2053,7 +2032,7 @@ class Compiler:
         else:
             raise CompilerError(
                 13,
-                f"Did not implement {node} yet :<",
+                f'Did not implement {node} yet :<',
                 None,
                 None,
                 None,

--- a/src/omni_compiler/omni.py
+++ b/src/omni_compiler/omni.py
@@ -236,7 +236,6 @@ def show_err_or_warn(e: Failed | Compiler.Warn, fp, file_content: str):
         msg = e.exception.msg
         end_col = e.exception.end_col
         end_line = e.exception.end_line
-        print(e)
         if isinstance(e.exception, CompilerError):
             filepath = e.exception.fp
             if e.compiler is None:

--- a/src/omni_compiler/runtime.py
+++ b/src/omni_compiler/runtime.py
@@ -10,36 +10,14 @@ def get_with_default(lst: list | tuple, index: int, default: Any = None):
 class Builtin:
     pass
 
-
+@dataclass 
+class RuntimeValue(Builtin):
+    name: str
 @dataclass
 class BuiltinFunction(Builtin):
     name: str
     req_args: int
     max_args: int | None
-
-
-class Environment:
-    def __init__(self, parent=None):
-        self.values = {}
-        self.parent = parent
-
-    def get(self, name):
-        if name in self.values:
-            return self.values[name]
-        if self.parent:
-            return self.parent.get(name)
-        raise NameError(f"Undefined variable '{name}'")
-
-    def set(self, name, value):
-        self.values[name] = value
-
-    def assign(self, name, value):
-        if name in self.values:
-            self.values[name] = value
-        elif self.parent:
-            self.parent.assign(name, value)
-        else:
-            raise NameError(f"Undefined variable '{name}'")
 
 
 NULL = 'NULL'
@@ -135,13 +113,6 @@ class ASTNode:
 @dataclass
 class Program(ASTNode):
     statements: list[ASTNode]
-
-
-@dataclass
-class DEPRECATEDModule(ASTNode):
-    body: Program
-    name: str
-
 
 @dataclass
 class BuiltinModulePointer(ASTNode):


### PR DESCRIPTION
Closes #18

## Summary by Sourcery

Introduce runtime special values for module metadata and tighten module/function handling across compiler and VM while cleaning up legacy constructs.

New Features:
- Expose current module name to programs via a new `_name` runtime value backed by a dedicated RuntimeValue/RuntimeType abstraction.
- Track module context at runtime with a VM module stack and new ENTER_MODULE/MAKE_MODULE behaviors so modules have stable names and exports carry origin metadata.

Bug Fixes:
- Prevent illegal use of runtime-only values in string representations by ensuring they are transformed before repr() is called.

Enhancements:
- Enforce exact argument counts for user-defined function calls in the VM, returning a dedicated invalid-argument error on mismatch.
- Refine module and export representations in the VM to store structured metadata, including module names and per-export origin, and adjust attribute access accordingly.
- Standardize string literal usage and minor formatting across the Python compiler for consistency and readability.
- Improve builtin handling so runtime-only values are converted to user-facing values when pushed onto the VM stack.

Chores:
- Remove deprecated or unused compiler/runtime constructs such as Environment, DEPRECATEDModule, and BuiltinModulePointer handling to simplify the codebase.