### PR TITLE
Add null :facepalm:

### DIFF
--- a/src/omni_compiler/main.py
+++ b/src/omni_compiler/main.py
@@ -66,6 +66,7 @@ SUB_ASSIGN = 'SUB_ASSIGN'
 MUL_ASSIGN = 'MUL_ASSIGN'
 DIV_ASSIGN = 'DIV_ASSIGN'
 MOD = 'MOD'
+NULL = 'NULL'
 
 
 @dataclass
@@ -111,6 +112,7 @@ KEYWORDS = {
     'export': EXPORT,
     '@': AT_RATE,
     'not': NOT,
+    'null': NULL
 }
 
 
@@ -1546,6 +1548,9 @@ class Compiler:
             self.emit(node.line, OP_PUSH_CONST, idx)
         elif isinstance(node, BareRequire):
             self.reqs += node.reqs
+        elif isinstance(node, Null):
+            idx = self.add_constant([T_NULL, ''])
+            self.emit(node.line, OP_PUSH_CONST, idx)
         elif isinstance(node, RequireStatement):
             consts: list[int] = []
             for item in node.reqs:


### PR DESCRIPTION
I completely forgot to make it so you can type out `null`.
The type has always existed. Running a function that doesn't have a return function does in fact return `null`, which you can test with `print(print())`, or the example below
```omniscript
func something() {
    # completely empty
}

print(something())
```
That also returns null
But now, you can use null, just with `print(null)`.

## Summary by Sourcery

Add support for the literal `null` keyword in the language so that it can be written and compiled like other constants.

New Features:
- Introduce a `null` keyword token and map it in the tokenizer so `null` can be used directly in source code.
- Compile `null` AST nodes into a `T_NULL` constant pushed onto the stack like other literals.