### PR TITLE
Refactor print() into println() and make a new print() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ OmniScript is a dynamic programming language that focuses on these main features
 
 - Variables
 - Functions
-- Basic builtins (print, input, to_(type))
+- Basic builtins (print, println, input, to_(type))
 - Arrays (methods indev)
 - The requirements syntax
 - Stack traces
@@ -34,20 +34,20 @@ Since OmniScript is still in early development, there aren't many features.
 Example:
 
 ```omniscript
-print('foo, bar', ' baz') # The print function takes multiple arguments, and concatenates them (without a space)
+println('foo, bar', ' baz') # The println function takes multiple arguments, and concatenates them with a space
 ```
 
 - Variables:
 
 ```omniscript
 this_is_a_var = 'foo'
-print(this_is_a_var)
+println(this_is_a_var)
 ```
 
 - Arithmetic:
 
 ```omniscript
-print(5 + 5 / 2)
+println(5 + 5 / 2)
 ```
 
 - Conditionals:
@@ -55,13 +55,13 @@ print(5 + 5 / 2)
 ```omniscript
 num = input('Enter a number\n>>> ') # The input function prints a message and waits for user input, returning the input given by the user.
 
-print(num == 5)
+println(num == 5)
 if num == 5 {
-  print('The number is equal to 5')
+  println('The number is equal to 5')
 } else if num == 10 {
-  print('The number is equal to 10')
+  println('The number is equal to 10')
 } else {
-  print('The number is not equal to 5 or 10')
+  println('The number is not equal to 5 or 10')
 }
 ```
 
@@ -75,34 +75,40 @@ func fib(n) {
   return fib(n - 1) + fib(n - 2)
 }
 
-print(fib(10)) # => 55
+println(fib(10)) # => 55
 ```
 
 - Requirements:
+
 ```omniscript
 @require strings.methods, attributes # A bare require statement will cause the VM to exit when starting to execute.
-print('hi'.upper())
+println('hi'.upper())
 
 @require types.arrays {
   arr = []
   arr.push('test')
 } else {
-  print('Arrays not supported') # Any code that tries to use arrays in here will fail to compile
+  println('Arrays not supported') # Any code that tries to use arrays in here will fail to compile
 }
 
 @require indexes # All bare require statements are collected. This whole program will fail on launch if the runtime doesn't support indexes
 # ...
 ```
+
 - Imports:
+
 main.om
+
 ```omniscript
 import some_mod
-print(some_mod.hi())
+println(some_mod.hi())
 ```
+
 some_mod.om
+
 ```omniscript
 export func hi() {
-  print('Hello from some_mod!')
+  println('Hello from some_mod!')
   return 'some value'
 }
 ```

--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -403,6 +403,11 @@ pub fn vm_to_bool(args: &[Value]) -> Result<Value, VmError> {
 
     Ok(Value::Bool(b))
 }
+pub fn vm_println(args: &[Value]) -> Result<Value, VmError> {
+    vm_print(args)?;
+    println!();
+    Ok(Value::Null)
+}
 pub fn vm_print(args: &[Value]) -> Result<Value, VmError> {
     let mut rust_args: Vec<String> = Vec::new();
     for item in args {
@@ -422,7 +427,13 @@ pub fn vm_print(args: &[Value]) -> Result<Value, VmError> {
         }
     }
 
-    println!("{}", rust_args.join(" "));
+    print!("{}", rust_args.join(" "));
+
+    io::stdout().flush().map_err(|e| VmError {
+        msg: format!("Failed to flush stdout: {}", e),
+        errcode: ErrCode::IoError, // Or a specific I/O error code
+    })?;
+    
     Ok(Value::Null)
 }
 pub fn vm_sleep(args: &[Value]) -> Result<Value, VmError> {
@@ -488,6 +499,10 @@ pub fn vmenv() -> Vec<Value> {
         Value::Func(OmniFunc::Builtin {
             name: "print".to_string(),
             func: vm_print,
+        }),
+        Value::Func(OmniFunc::Builtin {
+            name: "println".to_string(),
+            func: vm_println,
         }),
         Value::Func(OmniFunc::Builtin {
             name: "sleep".to_string(),
@@ -790,22 +805,22 @@ fn equal_to(a: Value, b: Value) -> Result<Value, VmError> {
 }
 
 fn not_equal_to(a: Value, b: Value) -> Result<Value, VmError> {
-    match (&a, &b) {
-        (Value::Integer(va), Value::Integer(vb)) => Ok(Value::Bool(va != vb)),
-        (Value::Bool(va), Value::Bool(vb)) => Ok(Value::Bool(va != vb)),
-        (Value::Integer(va), Value::Float(vb)) => Ok(Value::Bool(*va as f64 != *vb)),
-        (Value::Float(va), Value::Integer(vb)) => Ok(Value::Bool(*va != *vb as f64)),
-        (Value::Float(va), Value::Float(vb)) => Ok(Value::Bool(va != vb)),
-        (Value::String(va), Value::String(vb)) => Ok(Value::Bool(va != vb)),
-
-        _ => Err(VmError {
-            msg: format!(
-                "TypeError: Cannot check if a {} is equal to a {}",
-                a.display(),
-                b.display()
-            ),
-            errcode: ErrCode::TypeError,
-        }),
+    let a_display = a.display();
+    let b_display = b.display();
+    match equal_to(a, b) {
+        Ok(v) => match v {
+            Value::Bool(vb) => Ok(Value::Bool(!vb)),
+            _ => unreachable!(),
+        },
+        Err(_) => {
+            return Err(VmError {
+                msg: format!(
+                    "Cannot check if a(n) {} is not equal to a(n) {}",
+                    a_display, b_display
+                ),
+                errcode: ErrCode::TypeError,
+            });
+        }
     }
 }
 

--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -404,11 +404,11 @@ pub fn vm_to_bool(args: &[Value]) -> Result<Value, VmError> {
     Ok(Value::Bool(b))
 }
 pub fn vm_println(args: &[Value]) -> Result<Value, VmError> {
-    vm_print(args)?;
+    print_helper(args)?;
     println!();
     Ok(Value::Null)
 }
-pub fn vm_print(args: &[Value]) -> Result<Value, VmError> {
+fn print_helper(args: &[Value]) -> Result<(), VmError> {
     let mut rust_args: Vec<String> = Vec::new();
     for item in args {
         let out = vm_to_str(std::slice::from_ref(item));
@@ -426,9 +426,11 @@ pub fn vm_print(args: &[Value]) -> Result<Value, VmError> {
             Err(e) => return Err(e),
         }
     }
-
     print!("{}", rust_args.join(" "));
-
+    Ok(())
+}
+pub fn vm_print(args: &[Value]) -> Result<Value, VmError> {
+    print_helper(args)?;
     io::stdout().flush().map_err(|e| VmError {
         msg: format!("Failed to flush stdout: {}", e),
         errcode: ErrCode::IoError, // Or a specific I/O error code

--- a/src/omni_compiler/base_env.py
+++ b/src/omni_compiler/base_env.py
@@ -9,6 +9,7 @@ T_NULL = 6
 
 ASTenv: list[tuple[str, Builtin]] = [
     ('print', BuiltinFunction('print', 0, None)),
+    ('println', BuiltinFunction('println', 0, None)),
     ('sleep', BuiltinFunction('sleep', 1, 1)),
     ('input', BuiltinFunction('input', 0, 1)),
     ('to_str', BuiltinFunction('to_str', 1, 1)),

--- a/src/omni_compiler/omni.py
+++ b/src/omni_compiler/omni.py
@@ -201,7 +201,7 @@ def compile(
                 show_err_or_warn(e.value, filepath, file_content)
                 if warns > 0:
                     print(
-                        f'<red><b>Failed in {round(perf_counter() - start_time, 3)} seconds, </red><yellow>{warns} warnings emitted</yellow></b>'
+                        f'<b><red>Failed in {round(perf_counter() - start_time, 3)} seconds, </red><yellow>{warns} warnings emitted</yellow></b>'
                     )
                 else:
                     print(


### PR DESCRIPTION
resolves #41

## Summary by Sourcery

Introduce a separate println builtin while changing print to non-newline, buffered output, and simplify inequality handling via the existing equality logic.

New Features:
- Add a vm_println builtin that prints arguments followed by a newline and expose it in the VM environment.
- Expose a println builtin in the compiler base environment and reference it throughout the README examples.

Enhancements:
- Change the existing print builtin to write without an automatic newline and flush stdout explicitly for immediate output.
- Refactor the not-equal operator implementation to delegate to the equality logic and return the negated result, with clearer type error messaging.
- Tweak compiler diagnostic formatting to emphasize the failure message styling.