### PR TITLE
Dictionaries

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
             "console": "integratedTerminal",
             "args": [
                 "compile",
-                "examples/fib.om"
+                "tmp/new.om"
             ],
         },
     ]

--- a/build.py
+++ b/build.py
@@ -52,7 +52,7 @@ async def main():
     except* Exception as e:
         print('[red b]Build failed:')
         for ex in e.exceptions:
-            print(f'    [red b]{e}')
+            print(f'    [red b]{ex}')
 
 
 if __name__ == '__main__':

--- a/omni_vm/.vscode/launch.json
+++ b/omni_vm/.vscode/launch.json
@@ -10,14 +10,15 @@
             "request": "launch",
             "cargo": {
                 "args": [
-                    "run",
-                    "--bin=omni_vm",
+                    "build",
+                    "--bin=omni_vm"
                 ]
             },
             "args": [
                 "run",
-                "../tmp/floats.omc"
-            ]
+                "../tmp/tmp.omc"
+            ],
+            "sourceLanguages": ["Rust"]
         },
         {
             "name": "Debug unit tests in executable 'omni_vm'",

--- a/omni_vm/src/main.rs
+++ b/omni_vm/src/main.rs
@@ -145,7 +145,96 @@ impl Frame {
         self
     }
 }
-
+enum FncExit {
+    Exit(i32),
+    Continue,
+    None,
+}
+fn run_function(
+    frames: &mut Vec<Frame>,
+    mod_stack: &mut Vec<String>,
+    fnc: Rc<Value>,
+    args: Vec<ValueRef>,
+) -> Result<FncExit, VmError> {
+    let arg_count = args.len();
+    let func = match fnc.as_ref() {
+        Value::Func(f) => f,
+        _ => {
+            return Err(VmError {
+                msg: format!("Expected a function, got a {}", fnc.display()),
+                errcode: ErrCode::TypeError,
+            });
+        }
+    };
+    match func {
+        OmniFunc::Builtin { name: _, func } => {
+            let dereferenced_args: Vec<Value> =
+                args.iter().map(|arg| arg.as_ref().clone()).collect();
+            match func(dereferenced_args.as_slice()) {
+                Ok(v) => match v {
+                    Value::CallRequest(rec_func, args) => {
+                        return run_function(frames, mod_stack, Rc::new(Value::Func(rec_func.as_ref().clone())), args);
+                    }
+                    _ => frames.last_mut().unwrap().stack.push(Rc::new(v)),
+                },
+                Err(v) => match v.errcode {
+                    ErrCode::ExitSignal(c) => return Ok(FncExit::Exit(c)),
+                    _ => return Err(v),
+                },
+            }
+            Ok(FncExit::None)
+        }
+        OmniFunc::User {
+            entry,
+            local_count,
+            param_count,
+            closure,
+            name,
+            module,
+        } => {
+            mod_stack.push(module.to_string());
+            let mut fenv = Env {
+                values: vec![None; *local_count],
+                parent: Some(closure.clone()),
+                exports: HashMap::new(),
+            };
+            let mut rust_args: Vec<Option<ValueRef>> = vec![];
+            for arg in args {
+                rust_args.push(Some(arg))
+            }
+            if *param_count != arg_count {
+                return Err(VmError {
+                    msg: format!("Expected {} args, got {}", param_count, arg_count),
+                    errcode: ErrCode::InvalidArgCount,
+                });
+            }
+            for i in 0..*param_count {
+                fenv.values[i] = rust_args[i].clone()
+            }
+            let fframe = Frame::new()
+                .env(fenv)
+                .ret_addr(frames.last().unwrap().i)
+                .name(name.clone());
+            frames.push(fframe);
+            frames.last_mut().unwrap().i = *entry;
+            return Ok(FncExit::Continue);
+        }
+        OmniFunc::BuiltinMethod { name: _, func } => {
+            let itm = match frames.last_mut().unwrap().stack.pop() {
+                Some(v) => v,
+                None => {
+                    return Err(VmError {
+                        msg: "StackUnderflow".to_string(),
+                        errcode: ErrCode::StackUnderflow,
+                    });
+                }
+            };
+            let result = func(itm, args.as_slice())?;
+            frames.last_mut().unwrap().stack.push(result);
+            return Ok(FncExit::None);
+        }
+    }
+}
 impl VM {
     fn new(instructions: Vec<String>) -> Result<Self, VmError> {
         let mut const_table: Vec<Value> = vec![];
@@ -507,33 +596,33 @@ impl VM {
                 "BUILD_DICT" => {
                     let ops = match operators.get(1) {
                         Some(v) => v.parse::<usize>().unwrap(),
-                        None => return Err(
-                            VmError {
+                        None => {
+                            return Err(VmError {
                                 msg: "Invalid bytecode".to_string(),
-                                errcode: ErrCode::InvalidBytecode
-                            }
-                        )
+                                errcode: ErrCode::InvalidBytecode,
+                            });
+                        }
                     };
                     let mut map: Vec<(ValueRef, ValueRef)> = vec![];
 
-                    for _ in 0..ops { 
+                    for _ in 0..ops {
                         let k = match self.frames.last_mut().unwrap().stack.pop() {
                             Some(v) => v,
-                            None => return Err(
-                                VmError {
+                            None => {
+                                return Err(VmError {
                                     msg: "Stack Underflow".to_string(),
-                                    errcode: ErrCode::StackUnderflow
-                                }
-                            )
+                                    errcode: ErrCode::StackUnderflow,
+                                });
+                            }
                         };
                         let v = match self.frames.last_mut().unwrap().stack.pop() {
                             Some(v) => v,
-                            None => return Err(
-                                VmError {
+                            None => {
+                                return Err(VmError {
                                     msg: "Stack Underflow".to_string(),
-                                    errcode: ErrCode::StackUnderflow
-                                }
-                            )
+                                    errcode: ErrCode::StackUnderflow,
+                                });
+                            }
                         };
                         map.push((k, v));
                     }
@@ -549,9 +638,12 @@ impl VM {
                         self.global_env[operators[1].parse::<usize>().unwrap()].clone();
                     let to_push = match item {
                         Value::RuntimeValue(t) => match t {
-                            RuntimeType::Name => {
-                                Value::String(self.mod_stack.last().expect("Module stack underflow").to_string())
-                            }
+                            RuntimeType::Name => Value::String(
+                                self.mod_stack
+                                    .last()
+                                    .expect("Module stack underflow")
+                                    .to_string(),
+                            ),
                         },
                         _ => item,
                     };
@@ -612,18 +704,22 @@ impl VM {
                                 });
                             }
                         },
-                        Value::Dict(_) => match attrl.dict_get(&Value::String(attrand.to_string())){
+                        Value::Dict(_) => match attrl.dict_get(&Value::String(attrand.to_string()))
+                        {
                             Ok(v) => match v {
                                 Some(vs) => vs,
-                                None => return Err(
-                                    VmError {
-                                        msg: format!("Could not find an entry {} from the dict.", attrand),
-                                        errcode: ErrCode::AttributeError
-                                    }
-                                )
+                                None => {
+                                    return Err(VmError {
+                                        msg: format!(
+                                            "Could not find an entry {} from the dict.",
+                                            attrand
+                                        ),
+                                        errcode: ErrCode::AttributeError,
+                                    });
+                                }
                             },
-                            Err(_) => unreachable!()
-                        }
+                            Err(_) => unreachable!(),
+                        },
                         _ => {
                             if let Some(methods) = runtime::ATTRMAP.get(&attrl.get_tag()) {
                                 self.frames.last_mut().unwrap().stack.push(attrl.clone());
@@ -683,19 +779,19 @@ impl VM {
                                     });
                                 }
                             }
-                        },
+                        }
                         Value::Dict(_) => match item.dict_get(&rhs) {
                             Ok(v) => match v {
                                 Some(v) => self.push_to_stack(v),
-                                None => return Err(
-                                    VmError {
+                                None => {
+                                    return Err(VmError {
                                         msg: format!("Cannot find key {} from dict", rhs.display()),
-                                        errcode: ErrCode::IndexError
-                                    }
-                                )
+                                        errcode: ErrCode::IndexError,
+                                    });
+                                }
                             },
-                            Err(_) => unreachable!()
-                        }
+                            Err(_) => unreachable!(),
+                        },
                         _ => {
                             return Err(VmError {
                                 msg: format!("Cannot get an index from a {}", item.display()),
@@ -794,78 +890,16 @@ impl VM {
                             });
                         }
                     };
-                    let func = match func.as_ref() {
-                        Value::Func(f) => f,
-                        _ => {
-                            return Err(VmError {
-                                msg: format!("Expected a function, got a {}", func.display()),
-                                errcode: ErrCode::TypeError,
-                            });
-                        }
-                    };
-                    match func {
-                        OmniFunc::Builtin { name: _, func } => {
-                            let dereferenced_args: Vec<Value> =
-                                args.iter().map(|arg| arg.as_ref().clone()).collect();
-                            match func(dereferenced_args.as_slice()) {
-                                Ok(v) => self.push_to_stack(Rc::new(v)),
-                                Err(v) => match v.errcode {
-                                    ErrCode::ExitSignal(c) => return Ok(c),
-                                    _ => return Err(v),
-                                },
-                            }
-                        }
-                        OmniFunc::User {
-                            entry,
-                            local_count,
-                            param_count,
-                            closure,
-                            name,
-                            module
-                        } => {
-                            self.mod_stack.push(module.to_string());
-                            let mut fenv = Env {
-                                values: vec![None; *local_count],
-                                parent: Some(closure.clone()),
-                                exports: HashMap::new(),
-                            };
-                            let mut rust_args: Vec<Option<ValueRef>> = vec![];
-                            for arg in args {
-                                rust_args.push(Some(arg))
-                            }
-                            if *param_count != arg_count {
-                                return Err(VmError {
-                                    msg: format!(
-                                        "Expected {} args, got {}",
-                                        param_count, arg_count
-                                    ),
-                                    errcode: ErrCode::InvalidArgCount,
-                                });
-                            }
-                            for i in 0..*param_count {
-                                fenv.values[i] = rust_args[i].clone()
-                            }
-                            let fframe = Frame::new()
-                                .env(fenv)
-                                .ret_addr(self.get_i())
-                                .name(name.clone());
-                            self.frames.push(fframe);
-                            self.frames.last_mut().unwrap().i = *entry;
-                            continue;
-                        }
-                        OmniFunc::BuiltinMethod { name: _, func } => {
-                            let itm = match self.frames.last_mut().unwrap().stack.pop() {
-                                Some(v) => v,
-                                None => {
-                                    return Err(VmError {
-                                        msg: "StackUnderflow".to_string(),
-                                        errcode: ErrCode::StackUnderflow,
-                                    });
-                                }
-                            };
-                            let result = func(itm, args.as_slice())?;
-                            self.push_to_stack(result);
-                        }
+
+                    match run_function(
+                        &mut self.frames,
+                        &mut self.mod_stack,
+                        func,
+                        args,
+                    )? {
+                        FncExit::Continue => continue,
+                        FncExit::None => {}
+                        FncExit::Exit(e) => return Ok(e),
                     }
                 }
                 "RET" => {
@@ -1087,13 +1121,13 @@ impl VM {
                         name: name.to_string(),
                         module: match self.mod_stack.last() {
                             Some(v) => v.to_string(),
-                            None => return Err(
-                                VmError {
+                            None => {
+                                return Err(VmError {
                                     msg: "Module stack underflow".to_string(),
-                                    errcode: ErrCode::StackUnderflow
-                                }
-                            )
-                        }
+                                    errcode: ErrCode::StackUnderflow,
+                                });
+                            }
+                        },
                     }));
                     self.push_to_stack(item);
                 }

--- a/omni_vm/src/main.rs
+++ b/omni_vm/src/main.rs
@@ -504,6 +504,41 @@ impl VM {
                     }
                     self.push_to_stack(Rc::new(Value::Array(Rc::new(RefCell::new(items)))));
                 }
+                "BUILD_DICT" => {
+                    let ops = match operators.get(1) {
+                        Some(v) => v.parse::<usize>().unwrap(),
+                        None => return Err(
+                            VmError {
+                                msg: "Invalid bytecode".to_string(),
+                                errcode: ErrCode::InvalidBytecode
+                            }
+                        )
+                    };
+                    let mut map: Vec<(ValueRef, ValueRef)> = vec![];
+
+                    for _ in 0..ops { 
+                        let k = match self.frames.last_mut().unwrap().stack.pop() {
+                            Some(v) => v,
+                            None => return Err(
+                                VmError {
+                                    msg: "Stack Underflow".to_string(),
+                                    errcode: ErrCode::StackUnderflow
+                                }
+                            )
+                        };
+                        let v = match self.frames.last_mut().unwrap().stack.pop() {
+                            Some(v) => v,
+                            None => return Err(
+                                VmError {
+                                    msg: "Stack Underflow".to_string(),
+                                    errcode: ErrCode::StackUnderflow
+                                }
+                            )
+                        };
+                        map.push((k, v));
+                    }
+                    self.push_to_stack(Rc::new(Value::Dict(map)));
+                }
                 "PUSH_CONST" => {
                     let item: Value =
                         self.const_pool[operators[1].parse::<usize>().unwrap()].clone();
@@ -577,6 +612,18 @@ impl VM {
                                 });
                             }
                         },
+                        Value::Dict(_) => match attrl.dict_get(&Value::String(attrand.to_string())){
+                            Ok(v) => match v {
+                                Some(vs) => vs,
+                                None => return Err(
+                                    VmError {
+                                        msg: format!("Could not find an entry {} from the dict.", attrand),
+                                        errcode: ErrCode::AttributeError
+                                    }
+                                )
+                            },
+                            Err(_) => unreachable!()
+                        }
                         _ => {
                             if let Some(methods) = runtime::ATTRMAP.get(&attrl.get_tag()) {
                                 self.frames.last_mut().unwrap().stack.push(attrl.clone());
@@ -636,6 +683,18 @@ impl VM {
                                     });
                                 }
                             }
+                        },
+                        Value::Dict(_) => match item.dict_get(&rhs) {
+                            Ok(v) => match v {
+                                Some(v) => self.push_to_stack(v),
+                                None => return Err(
+                                    VmError {
+                                        msg: format!("Cannot find key {} from dict", rhs.display()),
+                                        errcode: ErrCode::IndexError
+                                    }
+                                )
+                            },
+                            Err(_) => unreachable!()
                         }
                         _ => {
                             return Err(VmError {

--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -221,7 +221,16 @@ impl Value {
             Value::Module(m) => format!("[module {}]", m.name),
             Value::Array(_) => "array".to_string(),
             Value::RuntimeValue(r) => format!("[runtime value '{}']", r.name()), // This should never be called
-            Value::Dict(_) => "dict".to_string(),
+            Value::Dict(_) => {
+                match self.dict_get(&Value::String("_display_type".to_string())).unwrap() {
+                    None => "dict".to_string(),
+                    Some(v) => match v.as_ref() {
+                        Value::String(s) => s.to_string(),
+                        _ => "dict".to_string()
+                    }
+                }
+                
+            },
             Value::CallRequest(r, _) => {
                 format!("[call request for {}]", Value::Func(r.as_ref().clone()).display())
             } // This should also never be called

--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -222,17 +222,22 @@ impl Value {
             Value::Array(_) => "array".to_string(),
             Value::RuntimeValue(r) => format!("[runtime value '{}']", r.name()), // This should never be called
             Value::Dict(_) => {
-                match self.dict_get(&Value::String("_display_type".to_string())).unwrap() {
+                match self
+                    .dict_get(&Value::String("_display_type".to_string()))
+                    .unwrap()
+                {
                     None => "dict".to_string(),
                     Some(v) => match v.as_ref() {
                         Value::String(s) => s.to_string(),
-                        _ => "dict".to_string()
-                    }
+                        _ => "dict".to_string(),
+                    },
                 }
-                
-            },
+            }
             Value::CallRequest(r, _) => {
-                format!("[call request for {}]", Value::Func(r.as_ref().clone()).display())
+                format!(
+                    "[call request for {}]",
+                    Value::Func(r.as_ref().clone()).display()
+                )
             } // This should also never be called
         }
     }
@@ -292,6 +297,30 @@ impl Value {
                 msg: format!("Expected a dict, got a(n) {}", self.display()),
                 errcode: ErrCode::TypeError,
             }),
+        }
+    }
+    pub fn dict_display(&self) -> Result<String, VmError> {
+        match self {
+            Value::Dict(d) => {
+                let mut out = String::new();
+                out.push('{');
+                for (i, (k, v)) in d.iter().enumerate() {
+                    out.push_str(&k.repr());
+                    out.push(':');
+                    out.push_str(&v.repr());
+                    if i != d.len()-1 {
+                        out.push_str(", ")
+                    }
+                }
+                out.push('}');
+                return Ok(out)
+            },
+            _ => Err(
+                VmError {
+                    msg: format!("Expected a dict, got a(n) {}", self.display()),
+                    errcode: ErrCode::TypeError
+                }
+            )
         }
     }
 }
@@ -381,6 +410,13 @@ pub fn vm_to_str(args: &[Value]) -> Result<Value, VmError> {
             v.name,
             v.exports.len()
         ))),
+        Value::Dict(_) => match item.dict_get(&Value::String("_str".to_string())).unwrap() {
+            Some(v) => match v.as_ref() {
+                Value::String(v) => Ok(Value::String(v.to_string())),
+                _ => Ok(Value::String(item.dict_display()?)),
+            },
+            _ => Ok(Value::String(item.dict_display()?)),
+        },
         _ => todo!("{}", item.display()),
     }
 }
@@ -486,7 +522,7 @@ fn print_helper(args: &[Value]) -> Result<(), VmError> {
                     rust_args.push(v);
                 } else {
                     return Err(VmError {
-                        msg: "Could not convert to string".to_string(),
+                        msg: format!("Could not convert to string"),
                         errcode: ErrCode::ConversionFailed,
                     });
                 }
@@ -662,8 +698,11 @@ fn vm_len(args: &[Value]) -> Result<Value, VmError> {
                         errcode: ErrCode::TypeError,
                     });
                 }
-                Some(   v) => match v.as_ref() {
-                    Value::Func(v) => Ok(Value::CallRequest(Rc::new(v.clone()), vec![Rc::new(args[0].clone())])), // TODO: perhaps find out how to not clone this
+                Some(v) => match v.as_ref() {
+                    Value::Func(v) => Ok(Value::CallRequest(
+                        Rc::new(v.clone()),
+                        vec![Rc::new(args[0].clone())],
+                    )), // TODO: perhaps find out how to not clone this
                     _ => {
                         return Err(VmError {
                             msg: format!("Expected `_len` to be a function, not a {}", v.display()),

--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -286,8 +286,14 @@ impl Value {
                 output
             }
             Value::RuntimeValue(_) => panic!("Illegal value received for repr()"), // It should've been converted on PUSH_BUILTIN
-            Value::Dict(_) => todo!(),                                             //TODO
-            Value::CallRequest(_, _) => panic!("Illegal value received for repr()"), // It should've been converted on PUSH_BUILTIN
+            Value::Dict(_) => match self.dict_get(&Value::String("_repr".to_string())).unwrap() {
+                Some(v) => match v.as_ref() {
+                    Value::String(v) => v.to_string(),
+                    _ => self.dict_display().unwrap(),
+                },
+                _ => self.dict_display().unwrap()
+            },
+            Value::CallRequest(_, _) => panic!("Illegal value received for repr()"), // It should've been converted on call
         }
     }
     pub fn dict_get(&self, key: &Value) -> Result<Option<ValueRef>, VmError> {
@@ -306,21 +312,19 @@ impl Value {
                 out.push('{');
                 for (i, (k, v)) in d.iter().enumerate() {
                     out.push_str(&k.repr());
-                    out.push(':');
+                    out.push_str(": ");
                     out.push_str(&v.repr());
-                    if i != d.len()-1 {
+                    if i != d.len() - 1 {
                         out.push_str(", ")
                     }
                 }
                 out.push('}');
-                return Ok(out)
-            },
-            _ => Err(
-                VmError {
-                    msg: format!("Expected a dict, got a(n) {}", self.display()),
-                    errcode: ErrCode::TypeError
-                }
-            )
+                return Ok(out);
+            }
+            _ => Err(VmError {
+                msg: format!("Expected a dict, got a(n) {}", self.display()),
+                errcode: ErrCode::TypeError,
+            }),
         }
     }
 }
@@ -687,28 +691,20 @@ fn vm_len(args: &[Value]) -> Result<Value, VmError> {
     match &args[0] {
         Value::String(v) => Ok(Value::Integer(v.len().try_into().unwrap())),
         Value::Array(v) => Ok(Value::Integer(v.borrow().len().try_into().unwrap())),
-        Value::Dict(_) => {
+        Value::Dict(d) => {
             match args[0]
                 .dict_get(&Value::String("_len".to_string()))
                 .unwrap()
             {
-                None => {
-                    return Err(VmError {
-                        msg: format!("Cannot find the `len()` of a {}", args[0].display()),
-                        errcode: ErrCode::TypeError,
-                    });
-                }
+                None => Ok(Value::Integer(d.len().try_into().unwrap())),
                 Some(v) => match v.as_ref() {
                     Value::Func(v) => Ok(Value::CallRequest(
                         Rc::new(v.clone()),
                         vec![Rc::new(args[0].clone())],
                     )), // TODO: perhaps find out how to not clone this
-                    _ => {
-                        return Err(VmError {
-                            msg: format!("Expected `_len` to be a function, not a {}", v.display()),
-                            errcode: ErrCode::TypeError,
-                        });
-                    }
+                    Value::Integer(v) => Ok(Value::Integer(*v)),
+                    _ => Ok(Value::Integer(d.len().try_into().unwrap()))
+                    
                 },
             }
         }

--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -19,6 +19,7 @@ pub static SUPPORTED_FEATURES: Lazy<Vec<String>> = Lazy::new(|| {
         "indexes".to_string(),
         "imports".to_string(),
         "runtime_values".to_string(),
+        "types.dicts".to_string(),
     ]
 });
 #[derive(Debug, Clone, PartialEq)]
@@ -75,6 +76,7 @@ pub enum ValueTag {
     Module = 8,
     Array = 9,
     RuntimeValue = 10,
+    Dict = 11,
 }
 
 impl TryFrom<i8> for ValueTag {
@@ -120,19 +122,57 @@ pub enum Value {
     Array(Rc<RefCell<Vec<ValueRef>>>),
     Null,
     RuntimeValue(RuntimeType),
+    Dict(Vec<(ValueRef, ValueRef)>),
+}
+fn eq_helper(a: &Value, other: &Value) -> Result<bool, ()> {
+    match (a, other) {
+        (Value::Integer(va), Value::Integer(vb)) => Ok(va == vb),
+        (Value::Bool(va), Value::Bool(vb)) => Ok(va == vb),
+        (Value::Integer(va), Value::Float(vb)) => Ok(*va as f64 == *vb),
+        (Value::Float(va), Value::Integer(vb)) => Ok(*va == *vb as f64),
+        (Value::Float(va), Value::Float(vb)) => Ok(va == vb),
+        (Value::String(va), Value::String(vb)) => Ok(va == vb),
+        (Value::Null, Value::Null) => Ok(true),
+        (Value::Null, other) | (other, Value::Null) => Ok(matches!(other, Value::Null)),
+        (Value::Array(va), Value::Array(vb)) => {
+            if Rc::ptr_eq(va, vb) {
+                return Ok(true);
+            }
+            Ok(*va.borrow() == *vb.borrow())
+        }
+        _ => Err(()),
+    }
+}
+
+impl PartialEq for OmniFunc {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                OmniFunc::User {
+                    name: a,
+                    module: ma,
+                    ..
+                },
+                OmniFunc::User {
+                    name: b,
+                    module: mb,
+                    ..
+                },
+            ) => a == b && ma == mb,
+            (OmniFunc::Builtin { name: a, .. }, OmniFunc::Builtin { name: b, .. }) => a == b,
+            (OmniFunc::BuiltinMethod { name: a, .. }, OmniFunc::BuiltinMethod { name: b, .. }) => {
+                a == b
+            }
+            _ => false,
+        }
+    }
 }
 
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Value::Integer(a), Value::Integer(b)) => a == b,
-            (Value::String(a), Value::String(b)) => a == b,
-            (Value::Bool(a), Value::Bool(b)) => a == b,
-            (Value::Float(a), Value::Float(b)) => a == b,
-            (Value::Null, Value::Null) => true,
-            (Value::Module(a), Value::Module(b)) => a == b,
-            (Value::Array(a), Value::Array(b)) => a.borrow().clone() == b.borrow().clone(),
-            _ => false,
+        match eq_helper(self, other) {
+            Ok(v) => v,
+            Err(_) => false,
         }
     }
 }
@@ -179,6 +219,7 @@ impl Value {
             Value::Module(m) => format!("[module {}]", m.name),
             Value::Array(_) => "array".to_string(),
             Value::RuntimeValue(r) => format!("[runtime value '{}']", r.name()),
+            Value::Dict(_) => "dict".to_string(),
         }
     }
     pub fn get_tag(&self) -> ValueTag {
@@ -192,6 +233,7 @@ impl Value {
             Value::Func(_) => ValueTag::Func,
             Value::Null => ValueTag::Null,
             Value::RuntimeValue(_) => ValueTag::RuntimeValue,
+            Value::Dict(_) => ValueTag::Dict,
         }
     }
     pub fn repr(&self) -> String {
@@ -223,10 +265,19 @@ impl Value {
                 output.push(']');
                 output
             }
-            Value::RuntimeValue(_) => panic!("Illegal value recieved for repr()"), // It should've been converted on PUSH_BUILTIN
+            Value::RuntimeValue(_) => panic!("Illegal value received for repr()"), // It should've been converted on PUSH_BUILTIN
+            Value::Dict(_) => todo!(),                                             //TODO
         }
     }
-}
+pub fn dict_get(&self, key: &Value) -> Result<Option<ValueRef>, VmError> {
+    match self {
+        Value::Dict(d) => Ok(d.iter().find(|(k, _)| **k == *key).map(|(_, v)| v.clone())),
+        _ => Err(VmError {
+            msg: format!("Expected a dict, got a(n) {}", self.display()),
+            errcode: ErrCode::TypeError,
+        }),
+    }
+}}
 #[derive(Debug, Clone)]
 pub enum OmniFunc {
     User {
@@ -435,7 +486,7 @@ pub fn vm_print(args: &[Value]) -> Result<Value, VmError> {
         msg: format!("Failed to flush stdout: {}", e),
         errcode: ErrCode::IoError, // Or a specific I/O error code
     })?;
-    
+
     Ok(Value::Null)
 }
 pub fn vm_sleep(args: &[Value]) -> Result<Value, VmError> {
@@ -787,24 +838,9 @@ fn gte(a: Value, b: Value) -> Result<Value, VmError> {
 }
 
 fn equal_to(a: Value, b: Value) -> Result<Value, VmError> {
-    match (&a, &b) {
-        (Value::Integer(va), Value::Integer(vb)) => Ok(Value::Bool(va == vb)),
-        (Value::Bool(va), Value::Bool(vb)) => Ok(Value::Bool(va == vb)),
-        (Value::Integer(va), Value::Float(vb)) => Ok(Value::Bool(*va as f64 == *vb)),
-        (Value::Float(va), Value::Integer(vb)) => Ok(Value::Bool(*va == *vb as f64)),
-        (Value::Float(va), Value::Float(vb)) => Ok(Value::Bool(va == vb)),
-        (Value::String(va), Value::String(vb)) => Ok(Value::Bool(va == vb)),
-        (Value::Null, Value::Null) => Ok(Value::Bool(true)),
-        (Value::Null, other) | (other, Value::Null) => {
-            Ok(Value::Bool(matches!(other, Value::Null)))
-        }
-        (Value::Array(va), Value::Array(vb)) => {
-            if Rc::ptr_eq(va, vb) {
-                return Ok(Value::Bool(true));
-            }
-            Ok(Value::Bool(*va.borrow() == *vb.borrow()))
-        }
-        _ => Err(VmError {
+    match eq_helper(&a, &b) {
+        Ok(v) => Ok(Value::Bool(v)),
+        Err(_) => Err(VmError {
             msg: format!(
                 "TypeError: Cannot check if a {} is equal to a {}",
                 a.display(),

--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -141,7 +141,8 @@ fn eq_helper(a: &Value, other: &Value) -> Result<bool, ()> {
                 return Ok(true);
             }
             Ok(*va.borrow() == *vb.borrow())
-        }
+        },
+        (Value::Func(a), Value::Func(b)) => Ok(a == b),
         _ => Err(()),
     }
 }

--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -77,6 +77,7 @@ pub enum ValueTag {
     Array = 9,
     RuntimeValue = 10,
     Dict = 11,
+    CallRequest = 12,
 }
 
 impl TryFrom<i8> for ValueTag {
@@ -123,6 +124,7 @@ pub enum Value {
     Null,
     RuntimeValue(RuntimeType),
     Dict(Vec<(ValueRef, ValueRef)>),
+    CallRequest(Rc<OmniFunc>, Vec<ValueRef>),
 }
 fn eq_helper(a: &Value, other: &Value) -> Result<bool, ()> {
     match (a, other) {
@@ -218,8 +220,11 @@ impl Value {
             Value::Null => "null".to_string(),
             Value::Module(m) => format!("[module {}]", m.name),
             Value::Array(_) => "array".to_string(),
-            Value::RuntimeValue(r) => format!("[runtime value '{}']", r.name()),
+            Value::RuntimeValue(r) => format!("[runtime value '{}']", r.name()), // This should never be called
             Value::Dict(_) => "dict".to_string(),
+            Value::CallRequest(r, _) => {
+                format!("[call request for {}]", Value::Func(r.as_ref().clone()).display())
+            } // This should also never be called
         }
     }
     pub fn get_tag(&self) -> ValueTag {
@@ -234,6 +239,7 @@ impl Value {
             Value::Null => ValueTag::Null,
             Value::RuntimeValue(_) => ValueTag::RuntimeValue,
             Value::Dict(_) => ValueTag::Dict,
+            Value::CallRequest(_, _) => ValueTag::CallRequest,
         }
     }
     pub fn repr(&self) -> String {
@@ -267,17 +273,19 @@ impl Value {
             }
             Value::RuntimeValue(_) => panic!("Illegal value received for repr()"), // It should've been converted on PUSH_BUILTIN
             Value::Dict(_) => todo!(),                                             //TODO
+            Value::CallRequest(_, _) => panic!("Illegal value received for repr()"), // It should've been converted on PUSH_BUILTIN
         }
     }
-pub fn dict_get(&self, key: &Value) -> Result<Option<ValueRef>, VmError> {
-    match self {
-        Value::Dict(d) => Ok(d.iter().find(|(k, _)| **k == *key).map(|(_, v)| v.clone())),
-        _ => Err(VmError {
-            msg: format!("Expected a dict, got a(n) {}", self.display()),
-            errcode: ErrCode::TypeError,
-        }),
+    pub fn dict_get(&self, key: &Value) -> Result<Option<ValueRef>, VmError> {
+        match self {
+            Value::Dict(d) => Ok(d.iter().find(|(k, _)| **k == *key).map(|(_, v)| v.clone())),
+            _ => Err(VmError {
+                msg: format!("Expected a dict, got a(n) {}", self.display()),
+                errcode: ErrCode::TypeError,
+            }),
+        }
     }
-}}
+}
 #[derive(Debug, Clone)]
 pub enum OmniFunc {
     User {
@@ -364,7 +372,7 @@ pub fn vm_to_str(args: &[Value]) -> Result<Value, VmError> {
             v.name,
             v.exports.len()
         ))),
-        _ => todo!(),
+        _ => todo!("{}", item.display()),
     }
 }
 pub fn vm_to_float(args: &[Value]) -> Result<Value, VmError> {
@@ -634,6 +642,28 @@ fn vm_len(args: &[Value]) -> Result<Value, VmError> {
     match &args[0] {
         Value::String(v) => Ok(Value::Integer(v.len().try_into().unwrap())),
         Value::Array(v) => Ok(Value::Integer(v.borrow().len().try_into().unwrap())),
+        Value::Dict(_) => {
+            match args[0]
+                .dict_get(&Value::String("_len".to_string()))
+                .unwrap()
+            {
+                None => {
+                    return Err(VmError {
+                        msg: format!("Cannot find the `len()` of a {}", args[0].display()),
+                        errcode: ErrCode::TypeError,
+                    });
+                }
+                Some(   v) => match v.as_ref() {
+                    Value::Func(v) => Ok(Value::CallRequest(Rc::new(v.clone()), vec![Rc::new(args[0].clone())])), // TODO: perhaps find out how to not clone this
+                    _ => {
+                        return Err(VmError {
+                            msg: format!("Expected `_len` to be a function, not a {}", v.display()),
+                            errcode: ErrCode::TypeError,
+                        });
+                    }
+                },
+            }
+        }
         _ => Err(VmError {
             msg: format!("Cannot find the `len()` of a {}", args[0].display()),
             errcode: ErrCode::TypeError,

--- a/src/omni_compiler/main.py
+++ b/src/omni_compiler/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from tkinter.dialog import DIALOG_ICON
 from typing import Any, Collection, Generator, Literal
 from omni_compiler import base_env
 from omni_compiler.runtime import (
@@ -67,7 +68,8 @@ MUL_ASSIGN = 'MUL_ASSIGN'
 DIV_ASSIGN = 'DIV_ASSIGN'
 MOD = 'MOD'
 NULL = 'NULL'
-
+DICT_STARTER = 'DICT_STARTER'
+COLON = 'COLON'
 
 @dataclass
 class CompilationException(Exception):
@@ -236,7 +238,9 @@ class Tokenizer:
         elif self.check('*='):
             self.advance(2)
             return Token(MUL_ASSIGN, None, start_line, start_col, self.line, self.col)
-
+        elif self.check('%{'):
+            self.advance(2)
+            return Token(DICT_STARTER, None, start_line, start_col, self.line, self.col)
         elif current_char == '+':
             self.advance(1)
             return Token(ADD, None, start_line, start_col, self.line, self.col)
@@ -255,6 +259,9 @@ class Tokenizer:
         elif current_char == '=':
             self.advance(1)
             return Token(ASSIGN, None, start_line, start_col, self.line, self.col)
+        elif current_char == ':':
+            self.advance(1)
+            return(Token(COLON, None, start_line, start_col, self.line, self.col))
         elif current_char == '-':
             self.advance(1)
             return Token(SUB, None, start_line, start_col, self.line, self.col)
@@ -687,6 +694,30 @@ class Parser:
             return Number(
                 token.line, token.col, token.end_line, token.end_col, token.value
             )
+        elif token.type == DICT_STARTER:
+            self.eat(DICT_STARTER)
+            if self.current_token.type == EOF:
+                self.incomplete_input()
+            items = []
+            self.skip_newline()
+            if self.current_token.type != RBRACE:
+                if self.current_token.type == EOF:
+                    self.incomplete_input()
+                self.skip_newline()
+                k = self.expr()
+                self.eat(COLON)
+                v = self.expr()
+                items.append((k, v))
+                while self.current_token.type == COMMA:
+                    self.eat(COMMA)
+                    if self.current_token.type == EOF:
+                        self.incomplete_input()
+                    self.skip_newline()
+                    k = self.expr()
+                    self.eat(COLON)
+                    v = self.expr()
+                    items.append((k, v))
+                return OmniDict(token.line, token.col, self.current_token.line, self.current_token.col, items)
         elif token.type == LBRACKET:
             self.eat(LBRACKET)
             if self.current_token.type == EOF:
@@ -1119,7 +1150,9 @@ class RequireStatement(ASTNode):
     statement: Block
     else_block: Block | None
 
-
+@dataclass
+class OmniDict(ASTNode):
+    vals: list[tuple[ASTNode, ASTNode]]
 @dataclass
 class Number(ASTNode):
     value: int
@@ -1287,6 +1320,7 @@ class Compiler:
         self.req_stack: list[
             Compiler.RequirementGroup
         ] = []  # LIFO stack for nested @require statements
+        self.warns: list[str] = []
         self.req_stack_not_allowed: list[
             Compiler.RequirementGroup
         ] = []  # for errors when using a feature where it isn't allowed, like the else branch of an @require statement
@@ -1754,16 +1788,17 @@ class Compiler:
                         if item[0] == node.func.rhs:
                             atr_itm = item
                             break
-                    if atr_itm is None:
-                        raise CompilerError(
-                            12,
-                            f'No attribute `{node.func.rhs}` found',
-                            node.line,
-                            node.col,
-                            node.end_line,
-                            node.end_col,
-                            self.mod_stack[-1].fp,
-                        )
+                    if atr_itm is None:    
+                        if 'types.dicts' not in self.reqs:    #TODO             
+                            raise CompilerError(
+                                12,
+                                f'No attribute `{node.func.rhs}` found',
+                                node.line,
+                                node.col,
+                                node.end_line,
+                                node.end_col,
+                                self.mod_stack[-1].fp,
+                            )
                 else:
                     if isinstance(exported.item, Function):  # pyright: ignore[reportPossiblyUnboundVariable]
                         params = exported.item.params  # pyright: ignore[reportPossiblyUnboundVariable]
@@ -1857,7 +1892,7 @@ class Compiler:
                                 )
 
                 else:
-                    raise NotImplementedError
+                    pass
 
             # compile argument expressions once
             for arg in node.args:
@@ -1905,7 +1940,7 @@ class Compiler:
                 else:
                     self.emit(node.line, OP_CALL, len(node.args))
             else:
-                raise NotImplementedError  # falling back for future call types
+                pass  # falling back for future call types #TODO
         elif isinstance(node, While):
             yield from self.compile_ins(node.expr)
             jmp = self.emit(node.line, 'JMPIFF', None)
@@ -1929,6 +1964,12 @@ class Compiler:
             for item in reversed(node.items):
                 yield from self.compile_ins(item)
             self.emit(node.line, 'BUILD_ARRAY', len(node.items))
+        elif isinstance(node, OmniDict):
+            yield from self.raise_for_req('types.dicts', 'Dictionary', 'Dictionaries', node)
+            for item in reversed(node.vals):
+                yield from self.compile_ins(item[1])
+                yield from self.compile_ins(item[0])
+            self.emit(node.line, 'BUILD_DICT', len(node.vals))
         elif isinstance(node, NOP):
             self.emit(0, 'NOP')
         elif isinstance(node, Function):
@@ -1992,29 +2033,40 @@ class Compiler:
         elif isinstance(node, Attribute):
             yield from self.raise_for_req('attributes', 'Attribute', 'Attributes', node)
             broken = False
-            if isinstance(node.lhs, Variable):
-                itm = self.get_var_obj(node.lhs.name)
-                if itm is not None and isinstance(itm[0].value, self.Module):
-                    exports = itm[0].value.exports
-                    for item in exports:
-                        if item.name == node.rhs:
+            if 'types.dicts' in self.reqs:
+                yield self.Warn(
+                    'Dictionaries are enabled, so OmniScript cannot check arguments or weather this attribute exists. This will be fixed once OmniScript releases a proper type checker',
+                    node.line,
+                    node.col,
+                    node.end_line,
+                    node.end_col,
+                    self.mod_stack[-1].fp,
+                    self,
+                )
+            else:
+                if isinstance(node.lhs, Variable):
+                    itm = self.get_var_obj(node.lhs.name)
+                    if itm is not None and isinstance(itm[0].value, self.Module):
+                        exports = itm[0].value.exports
+                        for item in exports:
+                            if item.name == node.rhs:
+                                broken = True
+                                break        
+                if not broken:
+                    for item in self.attrs:
+                        if item[0] == node.rhs:
                             broken = True
                             break
-            if not broken:
-                for item in self.attrs:
-                    if item[0] == node.rhs:
-                        broken = True
-                        break
-                if not broken:
-                    raise CompilerError(
-                        12,
-                        f'Could not find attribute {node.rhs}',
-                        node.line,
-                        node.col,
-                        node.end_line,
-                        node.end_col,
-                        self.mod_stack[-1].fp,
-                    )
+                    if not broken:
+                        raise CompilerError(
+                            12,
+                            f'Could not find attribute {node.rhs}',
+                            node.line,
+                            node.col,
+                            node.end_line,
+                            node.end_col,
+                            self.mod_stack[-1].fp,
+                        )
             yield from self.compile_ins(node.lhs)
             idx = self.add_constant((T_STRING, node.rhs))
             self.emit(node.line, 'GETATTR', idx)

--- a/src/omni_compiler/main.py
+++ b/src/omni_compiler/main.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from tkinter.dialog import DIALOG_ICON
 from typing import Any, Collection, Generator, Literal
 from omni_compiler import base_env
 from omni_compiler.runtime import (
@@ -15,7 +14,7 @@ from omni_compiler.runtime import (
     Builtin,
 )
 
-ADD = 'ADD'  # TODO: refactor this to be better
+ADD = 'ADD'  # TODO: refactor this to be better, perhaps into an enum
 INTEGER = 'INT'
 INT = INTEGER
 IDENTIFIER = 'IDENTIFIER'
@@ -717,6 +716,8 @@ class Parser:
                     self.eat(COLON)
                     v = self.expr()
                     items.append((k, v))
+                self.skip_newline()
+                self.eat(RBRACE)
                 return OmniDict(token.line, token.col, self.current_token.line, self.current_token.col, items)
         elif token.type == LBRACKET:
             self.eat(LBRACKET)
@@ -2035,7 +2036,7 @@ class Compiler:
             broken = False
             if 'types.dicts' in self.reqs:
                 yield self.Warn(
-                    'Dictionaries are enabled, so OmniScript cannot check arguments or weather this attribute exists. This will be fixed once OmniScript releases a proper type checker',
+                    'Dictionaries are enabled, so OmniScript cannot check arguments or whether this attribute exists. This will be fixed once OmniScript releases a proper type checker',
                     node.line,
                     node.col,
                     node.end_line,

--- a/src/omni_compiler/omni.py
+++ b/src/omni_compiler/omni.py
@@ -270,13 +270,11 @@ def show_err_or_warn(e: Failed | Compiler.Warn, fp, file_content: str):
                 if ln == i-2 and col is not None:
                     print(f'<blue><d>          | </d></blue>{color}{' ' * col}{('^' * (end_col - col if end_col else 1))}') 
                 print(f'{arr}<blue><d>{i:7} | </d></blue>{raw(cln)}', file=sys.stderr)
-            #if ln == len(splitted) - 1:
-            #    print(f'[blue dim]{spaces}  | [/]{color}{' ' * col}{('^' * (end_col - col if end_col else 1))}') 
         elif end_col is not None:
             from_lines = max(0, min(ln - 3, len(splitted)))
             to_lines = max(0, min(end_line + 4, len(splitted)))
             for i, cln in enumerate(splitted[from_lines:to_lines], from_lines + 1):
-                arr = f'{color}->[/]' if ln == i - 1 else '  '
+                arr = f'{color}->{end_color}' if ln == i - 1 else '  '
                 if ln == i-2 and col is not None:
                     print('<blue><d>       ... </d></blue>', file=sys.stderr)
                 elif not ln < i-1 < end_line:


### PR DESCRIPTION
Resolves #19

## Summary by Sourcery

Add first-class dictionary type support to the VM and compiler, along with call-request handling and minor tooling fixes.

New Features:
- Introduce a dictionary value type in the VM with construction, indexing, attribute access, and string/representation support.
- Extend the language syntax and parser to support dictionary literals using a dedicated token and AST node.
- Add a CallRequest value and helper to support user-defined behaviors (e.g., custom len) on dictionaries.

Enhancements:
- Refactor function invocation logic into a reusable helper that unifies built-in, user, and method calls and propagates exit signals.
- Relax compile-time attribute checking when dictionary types are enabled, emitting a warning instead of hard errors.
- Improve equality handling by centralizing comparison logic and adding PartialEq for OmniFunc and Value.
- Extend feature flags to advertise dictionary type support and enrich vm_to_str behavior for modules and dicts.
- Fix error display edge cases and minor output formatting in the compiler and build script.