### PR TITLE
Remove unused `IncorrectType` error code

### DIFF
--- a/omni_vm/src/runtime.rs
+++ b/omni_vm/src/runtime.rs
@@ -347,22 +347,21 @@ pub enum ErrCode {
     InvalidArgCount = 1,
     ConversionNotPossible = 2,
     ConversionFailed = 3,
-    IncorrectType = 4,
-    IoError = 5,
-    InvalidBytecode = 6,
-    VariableNotFound = 7,
-    StackUnderflow = 8,
-    TypeError = 9,
-    FuncNameStr = 11,
-    InvalidLocal = 12,
-    CompatibilityError = 13,
-    NoCode = 14,
-    ValueError = 15,
-    AttributeError = 17,
-    ExitSignal(i32) = 18,
-    InvalidOperation = 19,
-    IndexError = 20,
-    MathError = 21,
+    IoError = 4,
+    InvalidBytecode = 5,
+    VariableNotFound = 6,
+    StackUnderflow = 7,
+    TypeError = 8,
+    FuncNameStr = 9,
+    InvalidLocal = 10,
+    CompatibilityError = 11,
+    NoCode = 12,
+    ValueError = 13,
+    AttributeError = 14,
+    ExitSignal(i32) = 15,
+    InvalidOperation = 16,
+    IndexError = 17,
+    MathError = 18,
 }
 impl fmt::Display for ErrCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -542,7 +541,7 @@ pub fn vm_sleep(args: &[Value]) -> Result<Value, VmError> {
         _ => {
             return Err(VmError {
                 msg: format!("Expected integer or float, got {}", s.display()),
-                errcode: ErrCode::IncorrectType,
+                errcode: ErrCode::TypeError,
             });
         }
     }


### PR DESCRIPTION
Removes the unused `IncorrectType` error code in favor for `TypeError`

## Summary by Sourcery

Replace the unused `IncorrectType` error code with `TypeError` and normalize error code values accordingly.

Bug Fixes:
- Update `vm_sleep` to report `TypeError` instead of the removed `IncorrectType` error when given an invalid argument type.

Enhancements:
- Remove the `IncorrectType` variant from the `ErrCode` enum and consolidate type-related failures under `TypeError`.
- Reassign numeric values of remaining `ErrCode` variants to close the gap left by the removed variant.