### PR TITLE
fix(compiler): Make defining an empty dictionary work

### DIFF
--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -720,7 +720,7 @@ class Parser:
                     items.append((k, v))
                 self.skip_newline()
                 self.eat(RBRACE)
-                return KoniDict(token.line, token.col, self.current_token.line, self.current_token.col, items)
+            return KoniDict(token.line, token.col, self.current_token.line, self.current_token.col, items)
         elif token.type == LBRACKET:
             self.eat(LBRACKET)
             if self.current_token.type == EOF:

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -718,8 +718,8 @@ class Parser:
                     self.eat(COLON)
                     v = self.expr()
                     items.append((k, v))
-                self.skip_newline()
-                self.eat(RBRACE)
+            self.skip_newline()
+            self.eat(RBRACE)
             return KoniDict(token.line, token.col, self.current_token.line, self.current_token.col, items)
         elif token.type == LBRACKET:
             self.eat(LBRACKET)


### PR DESCRIPTION
Resolves #72. 

It was a one line indentation fix

## Summary by Sourcery

Bug Fixes:
- Fix dictionary literal parsing so that empty dictionaries are returned instead of causing a syntax or parsing error.