### PR TITLE
Revamp strings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
             "console": "integratedTerminal",
             "args": [
                 "compile",
-                "tmp/breaks.kn"
+                "tmp/new.kn"
             ],
         },
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
             "console": "integratedTerminal",
             "args": [
                 "compile",
-                "tmp/new.kn"
+                "tmp/breaks.kn"
             ],
         },
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,7 @@
         "fframe",
         "FOPEN",
         "FREAD",
+        "Fstring",
         "funcs",
         "garply",
         "GETATTR",

--- a/koni_lsp/editors/vscode/.vscode/tasks.json
+++ b/koni_lsp/editors/vscode/.vscode/tasks.json
@@ -51,6 +51,7 @@
 			},
 			"group": "build"
 		},
+
 		{
 			"label": "tasks: watch-tests",
 			"dependsOn": [

--- a/koni_lsp/editors/vscode/README.md
+++ b/koni_lsp/editors/vscode/README.md
@@ -1,6 +1,6 @@
-# koniscript README
+# koniscript language support
 
-This is the README for your extension "koniscript". After writing up a brief description, we recommend including the following sections.
+This is the official extension for [koniscript](https://github.com/DELOLCAT/koniscript).
 
 ## Features
 

--- a/koni_lsp/server.py
+++ b/koni_lsp/server.py
@@ -10,11 +10,13 @@ from koni_compiler import base_env
 from koni_compiler.main import (
     Compiler,
     CompilerError,
+    CompilerWarn,
     Parser,
     ParserError,
+    TokenType,
     Tokenizer,
     TokenizerError,
-    ParserWarn
+    Token
 )
 
 ADDITION = re.compile(r"^\s*(\d+)\s*\+\s*(\d+)\s*=\s*(\d+)?$")
@@ -34,19 +36,21 @@ class PublishDiagnosticServer(LanguageServer):
 
         ast_env, compiler_env, attrs = base_env.make_fresh_env()
 
-        logging.info("SOURCE:\n%s", document.source)
-        tkns = None
+        logging.info("SOURCEa:\n%s", document.source)
+        tkns: list[Token] | None = None
         try:
             tknr = Tokenizer(document.source)
             tkns = []
             while True:
+                logging.info('hi')
                 tkn = tknr.get_next_token()
                 if isinstance(tkn, list):
                     tkns += tkn
                 else:
                     tkns.append(tkn)
-                if tkns[-1].type == "EOF":
+                if tkns[-1].type == TokenType.EOF:
                     break
+            logging.info('break')
         except TokenizerError as e:
             diagnostics.append(
                 types.Diagnostic(
@@ -67,7 +71,18 @@ class PublishDiagnosticServer(LanguageServer):
                 p = psr.program()
                 while True:
                     try:
-                        next(p)
+                        w = next(p)
+                        diagnostics.append(
+                            types.Diagnostic(
+                                message = w.message,
+                                severity= types.DiagnosticSeverity.Warning,
+                                range = types.Range(
+                                    start = types.Position(line= w.line, character = w.col),
+                                    end= types.Position(line= w.end_line, character= w.end_col)
+                                ),
+                            )
+                        )
+                        logging.info(w)
                     except StopIteration as e:
                         program = e.value
                         break
@@ -93,7 +108,7 @@ class PublishDiagnosticServer(LanguageServer):
                 try:
                     a = next(it)
                     logging.info(a)
-                    if isinstance(a, ParserWarn):
+                    if isinstance(a, CompilerWarn):
                         diagnostics.append(
                             types.Diagnostic(
                                 range=types.Range(
@@ -131,6 +146,7 @@ class PublishDiagnosticServer(LanguageServer):
                                 message=e.msg,
                             )
                         )
+                    break
 
         self.diagnostics[document.uri] = (document.version, diagnostics)
         # ... run compiler ...

--- a/koni_lsp/server.py
+++ b/koni_lsp/server.py
@@ -40,8 +40,11 @@ class PublishDiagnosticServer(LanguageServer):
             tkns = []
             while True:
                 tkn = tknr.get_next_token()
-                tkns.append(tkn)
-                if tkn.type == "EOF":
+                if isinstance(tkn, list):
+                    tkns += tkn
+                else:
+                    tkns.append(tkn)
+                if tkns[-1].type == "EOF":
                     break
         except TokenizerError as e:
             diagnostics.append(

--- a/koni_lsp/server.py
+++ b/koni_lsp/server.py
@@ -14,6 +14,7 @@ from koni_compiler.main import (
     ParserError,
     Tokenizer,
     TokenizerError,
+    ParserWarn
 )
 
 ADDITION = re.compile(r"^\s*(\d+)\s*\+\s*(\d+)\s*=\s*(\d+)?$")
@@ -63,7 +64,13 @@ class PublishDiagnosticServer(LanguageServer):
         if tkns is not None:
             psr = Parser(tkns, ast_env)
             try:
-                program = psr.program()
+                p = psr.program()
+                while True:
+                    try:
+                        next(p)
+                    except StopIteration as e:
+                        program = e.value
+                        break
             except ParserError as e:
                 diagnostics.append(
                     types.Diagnostic(
@@ -86,7 +93,7 @@ class PublishDiagnosticServer(LanguageServer):
                 try:
                     a = next(it)
                     logging.info(a)
-                    if isinstance(a, Compiler.Warn):
+                    if isinstance(a, ParserWarn):
                         diagnostics.append(
                             types.Diagnostic(
                                 range=types.Range(

--- a/specs/documentation/errors.md
+++ b/specs/documentation/errors.md
@@ -145,6 +145,22 @@ println('This isn\'t a loop')
 break # <-
 ```
 
+### 16: Unterminated closing brace in format string
+
+Used when you forget to add a closing brace (`}`) in a format string
+
+```koniscript
+println(`This format literal has no ${closing brace`)
+```
+
+### 17: Invalid escape sequence
+
+Used when you use an invalid escape sequence in a string:
+
+```koniscript
+println('the escape sequence \g does not exist')
+```
+
 ## Runtime (VM) errors
 
 This section is for errors raised by the runtime (`kovm`)

--- a/specs/future/platform_files.md
+++ b/specs/future/platform_files.md
@@ -26,6 +26,7 @@ run grault 18 # A runtime value (similar to _name), which can perhaps change dur
 attr garply(1) on str # A method for strings with one argument (syntax tentative)
 @ver 3
 attr waldo on str # An attribute for strings (syntax tentative)
+func fred(1) converts to str # This will be used by the version system, and also format strings (`foo ${bar}` will call `fred(bar)` to convert bar to a string)
 
 const TEST = 'any_type' # These get ignored by the version system, as it just replaces these with the actual value.
 # The macro syntax isn't developed yet 
@@ -38,6 +39,8 @@ These can also be imported using a standard import, like `import std::random`, s
 The search paths will be the same as modules.
 
 Once the type-checker will be unveiled (Typescript-like), these will also support types.
+
+Above, you can see that `fred(1)` converts argument number 1 to a string. This is used by format strings and the type checker.
 
 ## Version System
 
@@ -116,6 +119,6 @@ json_native::load("{'foo': 'bar'}")
 
 There really is going to be one refactor, and it's for the good, which is replacing the hardcoded indexes for the prelude (`println()`, `input()`, etc.) to a platform file.
 
-In order to disable the `prelude.knp` file, you will add `@nostd` to your script.
+In order to disable the `prelude.knp` file, you will add `@nostd` to your script. If you use `@nostd` and don't provide a platform file with a string conversion funciton, format strings that use an argument which isn't a string will fail to compile
 
 As of now, the `prelude` file will reserve indexes from 0 to 30.

--- a/src/koni_compiler/koni.py
+++ b/src/koni_compiler/koni.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from colorama import init
 from koni_compiler.main import (
     CompilerError,
+    ParserError,
     Tokenizer,
     Parser,
     TokenType,
@@ -17,6 +18,7 @@ from koni_compiler.main import (
     CompilationException,
     ParserWarn,
     CompilerWarn,
+    TokenizerError,
     Warn
 )
 from koni_compiler import base_env
@@ -68,7 +70,7 @@ class Success(CompilationResult):
 def get_program(file_content: str, fp: str):
     try:
         current_env = copy.copy(base_env.compiler_env)
-        tknr = Tokenizer(file_content)
+        tknr = Tokenizer(file_content, fp)
         tkns: list[Token] = []
         while True:
             tkn = tknr.get_next_token()
@@ -126,7 +128,7 @@ def comp(
                     )  # TODO: columns
 
                 content = fp.read_text()
-                tmp = yield from get_program(content, filepath)
+                tmp = yield from get_program(content, fp)
                 if isinstance(tmp, Failed):
                     return tmp
                 import_program, _ = tmp
@@ -197,7 +199,7 @@ def compile(
             match value:
                 case Warn():
                     warns += 1
-                    show_err_or_warn(value, filepath, file_content)
+                    show_err_or_warn(value, file_content)
         except StopIteration as e:
             if isinstance(e.value, Success):
                 instructions = e.value.instructions
@@ -205,7 +207,7 @@ def compile(
             elif isinstance(e.value, Failed):
                 if tracebacks:  # To show Python tracebacks for development
                     raise e.value.exception
-                show_err_or_warn(e.value, filepath, file_content)
+                show_err_or_warn(e.value, file_content)
                 if warns > 0:
                     print(
                         f'<b><red>Failed in {round(perf_counter() - start_time, 3)} seconds, </red><yellow>{warns} warnings emitted</yellow></b>'
@@ -229,7 +231,7 @@ def compile(
     print(f'Wrote to {fp}')
 
 
-def show_err_or_warn(e: Failed | Warn, fp, file_content: str):
+def show_err_or_warn(e: Failed | Warn, file_content: str):
     if isinstance(e, Failed):
         color = '<red><b>'
         tag = f'<red><b>E{e.exception.code:02}'
@@ -239,6 +241,19 @@ def show_err_or_warn(e: Failed | Warn, fp, file_content: str):
         msg = e.exception.msg
         end_col = e.exception.end_col
         end_line = e.exception.end_line
+        
+        match e.exception:
+            case CompilerError(fp):
+                filepath = fp
+                if e.compiler is None:
+                    ln = None
+                else:
+                    file_content = e.compiler.sources[e.exception.fp]
+            case TokenizerError():
+                file_content = e.exception.file_content
+            case ParserError():
+                file_content = e.exception.file_content
+
         if isinstance(e.exception, CompilerError):
             filepath = e.exception.fp
             if e.compiler is None:
@@ -246,7 +261,7 @@ def show_err_or_warn(e: Failed | Warn, fp, file_content: str):
             else:
                 file_content = e.compiler.sources[e.exception.fp]
         else:
-            filepath = fp
+            filepath = e.exception.fp
 
     else:
         color = '<yellow><b>'
@@ -318,7 +333,7 @@ def run(
         try:
             value = next(it)
             if isinstance(value, CompilerWarn):
-                show_err_or_warn(value, filepath, file_content)
+                show_err_or_warn(value, file_content)
         except StopIteration as e:
             if isinstance(e.value, Success):
                 instructions = e.value.instructions
@@ -326,7 +341,7 @@ def run(
             elif isinstance(e.value, Failed):  # `elif` for IDE type recognition
                 if tracebacks:
                     raise e.value.exception
-                show_err_or_warn(e.value, filepath, file_content)
+                show_err_or_warn(e.value, file_content)
                 exit(1)  # Abort
             else:
                 raise  # Impossible

--- a/src/koni_compiler/koni.py
+++ b/src/koni_compiler/koni.py
@@ -15,6 +15,9 @@ from koni_compiler.main import (
     Program,
     Compiler,
     CompilationException,
+    ParserWarn,
+    CompilerWarn,
+    Warn
 )
 from koni_compiler import base_env
 import copy
@@ -62,7 +65,7 @@ class Success(CompilationResult):
     instructions: list[str]
 
 
-def get_program(file_content):
+def get_program(file_content: str, fp: str):
     try:
         current_env = copy.copy(base_env.compiler_env)
         tknr = Tokenizer(file_content)
@@ -75,8 +78,8 @@ def get_program(file_content):
                 tkns.append(tkn)
             if tkns[-1].type == TokenType.EOF:
                 break
-        psr: Parser = Parser(tkns, base_env.ASTenv)
-        program: Program = psr.program()
+        psr: Parser = Parser(tkns, base_env.ASTenv, fp=fp, file_content=file_content)
+        program: Program = yield from psr.program()
         return program, current_env
     except CompilationException as e:
         return Failed(None, e)
@@ -84,12 +87,12 @@ def get_program(file_content):
 
 def comp(
     file_content: str, filepath, features=None
-) -> Generator[Compiler.Warn | Compiler.ModuleRequest, Program, CompilationResult]:
+) -> Generator[Warn | Compiler.ModuleRequest, Program, CompilationResult]:
 
     if features is None:
         features = []
 
-    tmp = get_program(file_content)
+    tmp = yield from get_program(file_content, filepath)
 
     if isinstance(tmp, Failed):
         return tmp
@@ -123,10 +126,10 @@ def comp(
                     )  # TODO: columns
 
                 content = fp.read_text()
-                tmp = get_program(content)
+                tmp = yield from get_program(content, filepath)
                 if isinstance(tmp, Failed):
                     return tmp
-                import_program, import_env = tmp
+                import_program, _ = tmp
                 result = Compiler.ModuleReceived(import_program, str(fp), content)
 
             else:
@@ -191,9 +194,10 @@ def compile(
     while True:
         try:
             value = next(it)
-            if isinstance(value, Compiler.Warn):
-                warns += 1
-                show_err_or_warn(value, filepath, file_content)
+            match value:
+                case Warn():
+                    warns += 1
+                    show_err_or_warn(value, filepath, file_content)
         except StopIteration as e:
             if isinstance(e.value, Success):
                 instructions = e.value.instructions
@@ -225,7 +229,7 @@ def compile(
     print(f'Wrote to {fp}')
 
 
-def show_err_or_warn(e: Failed | Compiler.Warn, fp, file_content: str):
+def show_err_or_warn(e: Failed | Warn, fp, file_content: str):
     if isinstance(e, Failed):
         color = '<red><b>'
         tag = f'<red><b>E{e.exception.code:02}'
@@ -254,7 +258,17 @@ def show_err_or_warn(e: Failed | Compiler.Warn, fp, file_content: str):
         ln = e.line
         msg = e.message
         filepath = e.fp
-        file_content = e.compiler.sources[e.fp]
+        match e:
+            case CompilerWarn():
+                file_content = e.compiler.sources[e.fp]
+            case ParserWarn():
+                if e.parser.file_content:
+                    file_content = e.parser.file_content
+                else:
+                    file_content = '<unknown>'
+            case _:
+                file_content = '<unknown>' # just in case somebody uses this function for their own Warn type
+            
 
     print()
     print(f'{tag}: {msg}:', file=sys.stderr)
@@ -279,7 +293,7 @@ def show_err_or_warn(e: Failed | Compiler.Warn, fp, file_content: str):
             for i, cln in enumerate(splitted[from_lines:to_lines], from_lines + 1):
                 arr = f'{color}->{end_color}' if ln == i - 1 else '  '
                 if ln == i-2 and col is not None:
-                    print('<blue><d>       ... </d></blue>', file=sys.stderr)
+                    print('<blue><d>        ... </d></blue>', file=sys.stderr)
                 elif not ln < i-1 < end_line:
                     print(f'{arr}<blue><d>{i:7} | </d></blue>{raw(cln)}', file=sys.stderr)
                 if ln <= i-1 <= end_line and col is not None:
@@ -303,7 +317,7 @@ def run(
     while True:
         try:
             value = next(it)
-            if isinstance(value, Compiler.Warn):
+            if isinstance(value, CompilerWarn):
                 show_err_or_warn(value, filepath, file_content)
         except StopIteration as e:
             if isinstance(e.value, Success):

--- a/src/koni_compiler/koni.py
+++ b/src/koni_compiler/koni.py
@@ -69,8 +69,11 @@ def get_program(file_content):
         tkns: list[Token] = []
         while True:
             tkn = tknr.get_next_token()
-            tkns.append(tkn)
-            if tkn.type == TokenType.EOF:
+            if isinstance(tkn, list):
+                tkns += tkn
+            else:
+                tkns.append(tkn)
+            if tkns[-1].type == TokenType.EOF:
                 break
         psr: Parser = Parser(tkns, base_env.ASTenv)
         program: Program = psr.program()

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -13,8 +13,7 @@ from koni_compiler.runtime import (
     Program,
     Builtin,
 )
-from enum import Enum
-
+from enum import Enum, auto
 
 class TokenType(Enum):
     ADD = 'ADD'
@@ -72,6 +71,11 @@ class TokenType(Enum):
     DICT_STARTER = 'DICT_STARTER'
     COLON = 'COLON'
     BREAK = 'BREAK'
+    BACKTICK = 'BACKTICK'
+    FStringStart = 'FStringStart'
+    FStringExpr = 'FStringExpr'
+    FStringExprEnd = 'FStringExprEnd'
+    FStringEnd = 'FstringEnd'
 
 
 PRECEDENCE = {
@@ -149,12 +153,34 @@ class Token:
     end_col: int
 
 
+class FormatStringComponent:
+    pass
+
+
+@dataclass
+class FormatStringStr(FormatStringComponent):
+    value: str
+
+
+@dataclass
+class FormatStringExpr(FormatStringComponent):
+    expr: str
+
+
 class Tokenizer:
+    class TokenizerMode(Enum):
+        Normal = auto()
+        FStringEpr = auto()
+        FStringStr = auto()
+
     def __init__(self, string: str):
         self.string: str = string
         self.current_idx: int = 0
         self.line: int = 0
         self.col: int = 0
+        # self.mode: Tokenizer.TokenizerMode = self.TokenizerMode.Normal
+        self.fstring_count = 0
+        self.mode_stack: list[Tokenizer.TokenizerMode] = [self.TokenizerMode.Normal]
 
     def advance(self, steps: int = 1) -> str | None:
         if steps <= 0:  # To make sure that `ch` isn't `Unbound`
@@ -194,15 +220,152 @@ class Tokenizer:
         end = self.current_idx + len(text)
         return self.string[self.current_idx : end] == text
 
+    def tokenize_string(self, char: Literal["'", '"'], start_line, start_col) -> Token:
+        self.advance(1)
+        value = ''
+        while self.get_current_char() is not None and self.get_current_char() != char:
+            if self.get_current_char() == '\\':
+                self.advance()
+                match self.get_current_char():
+                    case 'n':
+                        value += '\n'
+                    case 't':
+                        value += '\t'
+                    case _:
+                        value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
+            else:
+                value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
+            self.advance()
+        if self.get_current_char() != char:
+            raise TokenizerError(
+                1,
+                'Unterminated string literal',
+                start_line,
+                start_col,
+                self.line,
+                self.col,
+            )
+        self.advance()
+        return Token(
+            TokenType.STRING, value, start_line, start_col, self.line, self.col
+        )
+
+    def tokenize_format_string(self, start_line, start_col) -> Token | list[Token]:
+        if self.mode_stack[-1] == self.TokenizerMode.FStringStr:
+            value = ''
+            while (
+                self.get_current_char() is not None and self.get_current_char() != '`'
+            ):
+                if self.get_current_char() == '\\':
+                    value += self.parse_escape_seq('`')
+                elif self.check('${'):
+                    self.advance(2)
+                    self.mode_stack.append(self.TokenizerMode.FStringEpr)
+                    return [
+                        Token(
+                            TokenType.STRING,
+                            value,
+                            start_line,
+                            start_col,
+                            self.line,
+                            self.col,
+                        ),
+                        Token(
+                            TokenType.FStringExpr,
+                            None,
+                            self.line,
+                            self.col,
+                            self.line,
+                            self.col,
+                        ),
+                    ]
+                else:
+                    value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
+                    self.advance()
+            if self.get_current_char() != '`':
+                raise TokenizerError(
+                    1,
+                    'Unterminated string literal',
+                    start_line,
+                    start_col,
+                    self.line,
+                    self.col + 1,
+                )
+
+            self.advance()
+            self.mode_stack.pop()
+            if len(value) > 0:
+                return [
+                    Token(
+                        TokenType.STRING,
+                        value,
+                        start_line,
+                        start_col,
+                        self.line,
+                        self.col,
+                    ),
+                    Token(
+                        TokenType.FStringEnd,
+                        None,
+                        start_line,
+                        start_col,
+                        self.line,
+                        self.col,
+                    ),
+                ]
+            return Token(
+                TokenType.FStringEnd, None, start_line, start_col, self.line, self.col
+            )
+
+        # elif self.mode_stack[-1] == self.TokenizerMode.FStringEpr:
+        #    if self.get_current_char() == '}':
+        #        self.mode_stack.pop()
+        #        return Token(TokenType.FStringEnd, None, self.line, self.col, self.line, self.col)
+        #    return self.get_next_token()
+        else:
+            self.mode_stack.append(self.TokenizerMode.FStringStr)
+            self.fstring_count += 1
+            return Token(
+                TokenType.FStringStart, None, self.line, self.col, self.line, self.col
+            )
+
+    def parse_escape_seq(self, char: Literal['"', "'", '`']):
+        if self.get_current_char() == '\\':
+            self.advance()
+        match self.get_current_char():
+            case 'n':
+                return '\n'
+            case 'r':
+                return '\r'
+            case 't':
+                return '\t'
+            case '\\':
+                return '\\'
+            case _:
+                if self.get_current_char() == char:
+                    return char
+                raise TokenizerError(
+                    17,
+                    f'Invalid escape sequence \\{self.get_current_char()}',
+                    self.line,
+                    self.col,
+                    self.line,
+                    self.col + 1,
+                )
+
     def get_next_token(self):  # sourcery skip: extract-method, low-code-quality
-        self.skip_whitespace()
         start_line = self.line
         start_col = self.col
+        if self.mode_stack[-1] == self.TokenizerMode.FStringStr:
+            return self.tokenize_format_string(start_line, start_col)
+        self.skip_whitespace()
         current_char = self.get_current_char()
         if current_char is None:
             return Token(
                 TokenType.EOF, None, start_line, start_col, self.line, self.col
             )  # End of input
+        start_line = self.line
+        start_col = self.col
 
         if current_char.isdigit():
             value = ''
@@ -367,6 +530,18 @@ class Tokenizer:
             )
         elif current_char == '}':
             self.advance(1)
+            if self.mode_stack[-1] == self.TokenizerMode.FStringEpr:
+                # self.mode = self.TokenizerMode.FStringStr
+                self.mode_stack.pop()
+                return Token(
+                    TokenType.FStringExprEnd,
+                    None,
+                    start_line,
+                    start_col,
+                    self.line,
+                    self.col,
+                )
+
             return Token(
                 TokenType.RBRACE, None, start_line, start_col, self.line, self.col
             )
@@ -396,68 +571,12 @@ class Tokenizer:
                 TokenType.GREATER_THAN, None, start_line, start_col, self.line, self.col
             )
         elif current_char == '"':
-            self.advance(1)
-            value = ''
-            while (
-                self.get_current_char() is not None and self.get_current_char() != '"'
-            ):
-                if self.get_current_char() == '\\':
-                    self.advance()
-                    match self.get_current_char():
-                        case 'n':
-                            value += '\n'
-                        case 't':
-                            value += '\t'
-                        case _:
-                            value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
-                else:
-                    value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
-                self.advance()
-            if self.get_current_char() != '"':
-                raise TokenizerError(
-                    1,
-                    'Unterminated string literal',
-                    self.line,
-                    self.col,
-                    self.line,
-                    self.col + 1,
-                )
-            self.advance()
-            return Token(
-                TokenType.STRING, value, start_line, start_col, self.line, self.col
-            )
+            return self.tokenize_string('"', start_line, start_col)
         elif current_char == "'":
-            self.advance(1)
-            value = ''
-            while (
-                self.get_current_char() is not None and self.get_current_char() != "'"
-            ):
-                if self.get_current_char() == '\\':
-                    self.advance()
-                    match self.get_current_char():
-                        case 'n':
-                            value += '\n'
-                        case 't':
-                            value += '\t'
-                        case _:
-                            value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
-                else:
-                    value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
-                self.advance()
-            if self.get_current_char() != "'":
-                raise TokenizerError(
-                    1,
-                    'Unterminated string literal',
-                    self.line,
-                    self.col,
-                    self.line,
-                    self.col + 1,
-                )
+            return self.tokenize_string("'", start_line, start_col)
+        elif current_char == '`':
             self.advance()
-            return Token(
-                TokenType.STRING, value, start_line, start_col, self.line, self.col
-            )
-
+            return self.tokenize_format_string(start_line, start_col)
         elif current_char.isalpha() or current_char == '_':
             to_return = current_char
             self.advance()
@@ -890,6 +1009,73 @@ class Parser:
             return String(
                 token.line, token.col, token.end_line, token.end_col, token.value
             )
+        elif token.type == TokenType.FStringStart:
+            start_line = token.line
+            start_col = token.col
+            self.eat(TokenType.FStringStart)
+            out: list[ASTNode] = []
+            while True:
+                if self.current_token.type == TokenType.FStringExpr:
+                    self.eat(TokenType.FStringExpr)
+                    t = self.expr()
+                    if not isinstance(t, String):
+                        t = Call(
+                            t.line,
+                            t.col,
+                            t.end_line,
+                            t.end_col,
+                            Variable(t.line, t.col, t.end_line, t.end_col, 'to_str'),
+                            [t],
+                        )
+
+                    out.append(t)
+                elif self.current_token.type == TokenType.FStringExprEnd:
+                    self.eat(TokenType.FStringExprEnd)
+                elif self.current_token.type == TokenType.FStringEnd:
+                    self.eat(TokenType.FStringEnd)
+                    break
+                else:
+                    t = self.expr()
+                    out.append(t)
+            if len(out) == 1:
+                # raise ParserWarn( # TODO: Make parser warnings
+                #     18,
+                #     'Format string without any expressions',
+                #     start_line,
+                #     start_col,
+                #     self.current_token.line,
+                #     self.current_token.col
+                # )
+                return out[0]
+            rhs = out[1]
+            for node in out[2:]:
+                rhs = BinOp(
+                    self.current_token.line,
+                    self.current_token.col,
+                    self.current_token.end_line,
+                    self.current_token.end_col,
+                    rhs,
+                    BinOpType.ADD,
+                    node,
+                )
+            node = BinOp(
+                self.current_token.line,
+                self.current_token.col,
+                self.current_token.end_line,
+                self.current_token.end_col,
+                out[0],
+                BinOpType.ADD,
+                rhs,
+            )
+            return node
+
+            # for item in token.value:
+            #     if isinstance(item, FormatStringStr):
+            #         val.append(item.value)
+            #     elif isinstance(item, FormatStringExpr):
+            #         val.append(self.expr())
+            #     else:
+            #         assert_never(item)
         elif token.type == TokenType.BOOL:
             self.eat(TokenType.BOOL)
             return Bool(
@@ -1369,6 +1555,11 @@ class Assign(ASTNode):
 @dataclass
 class String(ASTNode):
     value: str
+
+
+@dataclass
+class FormatString(ASTNode):
+    value: list[ASTNode]
 
 
 @dataclass

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -490,8 +490,6 @@ class Tokenizer:
         elif self.is_str_prefix():
             raw = False
             multiline = False
-            adv = 1
-            c = False
             while True:
                 match self.get_current_char():
                     case 'm':
@@ -794,14 +792,32 @@ class BinOpType(Enum):
 class UnaryOpType(Enum):
     NEG = 'NEG'
     NOT = TokenType.NOT
+@dataclass
+class Warn:  # TODO: make a warning code
+    message: str
+    line: int
+    col: int
+    end_line: int
+    end_col: int
+    fp: str
 
+
+@dataclass
+class ParserWarn(Warn):  # TODO: make a warning code
+    parser: Parser
+    
+@dataclass
+class CompilerWarn(Warn):
+    compiler: Compiler
 
 class Parser:
-    def __init__(self, tokens: list[Token], base_env: list[tuple], repl: bool = False):
+    def __init__(self, tokens: list[Token], base_env: list[tuple], repl: bool = False, fp: str = '<unknown>', file_content: str| None =None):
         self.base_env = base_env
         self.tokens = tokens
         self.pos = 0
         self.repl = repl
+        self.fp = fp
+        self.file_content: str | None = file_content
         self.current_token = (
             self.tokens[0] if self.tokens else Token(TokenType.EOF, None, 0, 0, 0, 0)
         )
@@ -831,14 +847,15 @@ class Parser:
         else:
             self.current_token = Token(TokenType.EOF, None, 0, 0, 0, 0)
 
-    def arithmetic_expr(self):
-        node = self.term()
+    def arithmetic_expr(self) -> Generator[ParserWarn, None, ASTNode]:
+        node = yield from self.term()
         while self.current_token and self.current_token.type in (
             TokenType.ADD,
             TokenType.SUB,
         ):
             op = self.current_token.type
             self.eat(op)
+            t = yield from self.term()
             node = BinOp(
                 self.current_token.line,
                 self.current_token.col,
@@ -846,15 +863,16 @@ class Parser:
                 self.current_token.end_col,
                 node,
                 BinOpType(op),
-                self.term(),
+                t,
             )
         return node
 
     def expr(self):
-        node = self.logical_and()
+        node = yield from self.logical_and()
         while self.current_token.type == TokenType.OR:
             op = self.current_token.type
             self.eat(op)
+            e = yield from self.logical_and()
             node = BinOp(
                 self.current_token.line,
                 self.current_token.col,
@@ -862,29 +880,32 @@ class Parser:
                 self.current_token.end_col,
                 node,
                 BinOpType(op),
-                self.logical_and(),
+                e,
             )
 
         return node
 
-    def logical_not(self):
+    def logical_not(self) -> Generator[ParserWarn, None, ASTNode]:
         if self.current_token.type == TokenType.NOT:
             self.eat(TokenType.NOT)
+            e = yield from self.logical_not()
             return UnaryOp(
                 self.current_token.line,
                 self.current_token.col,
                 self.current_token.end_line,
                 self.current_token.end_col,
                 UnaryOpType.NOT,
-                self.logical_not(),
+                e,
             )
-        return self.equality()
+        e = yield from self.equality()
+        return e
 
     def logical_and(self):
-        node = self.logical_not()
+        node = yield from self.logical_not()
         while self.current_token.type == TokenType.AND:
             op = self.current_token.type
             self.eat(op)
+            e = yield from self.equality()
             node = BinOp(
                 self.current_token.line,
                 self.current_token.col,
@@ -892,12 +913,12 @@ class Parser:
                 self.current_token.end_col,
                 node,
                 BinOpType(op),
-                self.equality(),
+                e,
             )
         return node
 
-    def comparison(self):
-        node = self.arithmetic_expr()
+    def comparison(self) -> Generator[ParserWarn, None, ASTNode]:
+        node = yield from self.arithmetic_expr()
         while self.current_token.type in (
             TokenType.LT,
             TokenType.GT,
@@ -906,6 +927,7 @@ class Parser:
         ):
             op = self.current_token.type
             self.eat(op)
+            e = yield from self.arithmetic_expr()
             node = BinOp(
                 self.current_token.line,
                 self.current_token.col,
@@ -913,15 +935,16 @@ class Parser:
                 self.current_token.end_col,
                 node,
                 BinOpType(op),
-                self.arithmetic_expr(),
+                e,
             )
         return node
 
-    def equality(self):
-        node = self.comparison()
+    def equality(self) -> Generator[ParserWarn, None, ASTNode]:
+        node = yield from self.comparison()
         while self.current_token.type in (TokenType.EQUAL_TO, TokenType.NOT_EQUAL_TO):
             op = self.current_token.type
             self.eat(op)
+            c = yield from self.comparison()
             node = BinOp(
                 self.current_token.line,
                 self.current_token.col,
@@ -929,12 +952,12 @@ class Parser:
                 self.current_token.end_col,
                 node,
                 BinOpType(op),
-                self.comparison(),
+                c,
             )
         return node
 
-    def term(self):
-        node = self.power()
+    def term(self) -> Generator[ParserWarn, None, ASTNode]:
+        node = yield from self.power()
         while self.current_token and self.current_token.type in (
             TokenType.MUL,
             TokenType.DIV,
@@ -942,6 +965,7 @@ class Parser:
         ):
             op = self.current_token.type
             self.eat(op)
+            p = yield from self.power()
             node = BinOp(
                 self.current_token.line,
                 self.current_token.col,
@@ -949,15 +973,16 @@ class Parser:
                 self.current_token.end_col,
                 node,
                 BinOpType(op),
-                self.power(),
+                p,
             )
         return node
 
-    def power(self):
-        node = self.factor()
+    def power(self) -> Generator[ParserWarn, None, ASTNode]:
+        node = yield from self.factor()
         if self.current_token and self.current_token.type == TokenType.POW:
             op = self.current_token.type
             self.eat(TokenType.POW)
+            p = yield from self.power()
             node = BinOp(
                 self.current_token.line,
                 self.current_token.col,
@@ -965,26 +990,28 @@ class Parser:
                 self.current_token.end_col,
                 node,
                 BinOpType(op),
-                self.power(),
+                p,
             )  # right-associative
         return node
 
-    def factor(self):
+    def factor(self) -> Generator[ParserWarn, None, ASTNode]:
         token = self.current_token
         if token.type == TokenType.SUB:
             self.eat(TokenType.SUB)
+            f = yield from self.factor()
             return UnaryOp(
                 token.line,
                 token.col,
                 token.end_line,
                 token.end_col,
                 UnaryOpType.NEG,
-                self.factor(),
+                f,
             )
-        return self.postfix()
+        r = yield from self.postfix()
+        return r
 
-    def postfix(self):
-        node = self.primary()
+    def postfix(self) -> Generator[ParserWarn, None, ASTNode]:
+        node = yield from self.primary()
 
         while self.current_token.type in (
             TokenType.DOT,
@@ -1024,11 +1051,15 @@ class Parser:
                 self.skip_newline()
 
                 if self.current_token.type != TokenType.RPAREN:
-                    args.append(self.expr())
+                    e = yield from self.expr()
+                    args.append(e)
 
                     while self.current_token.type == TokenType.COMMA:
                         self.eat(TokenType.COMMA)
                         self.skip_newline()
+                        e = yield from self.expr()
+                        args.append(e)
+
                         args.append(self.expr())
 
                 self.skip_newline()
@@ -1044,7 +1075,7 @@ class Parser:
                 ln = self.current_token.line
                 col = self.current_token.col
                 self.eat(TokenType.LBRACKET)
-                idx = self.expr()
+                idx = yield from self.expr()
                 end_tok = self.eat(TokenType.RBRACKET)
                 node = GetIndex(ln, col, end_tok.end_line, end_tok.end_col, node, idx)
 
@@ -1054,7 +1085,7 @@ class Parser:
         while self.current_token.type == TokenType.NEWLINE:
             self.eat(TokenType.NEWLINE)
 
-    def primary(self):
+    def primary(self) -> Generator[ParserWarn, None, ASTNode]:
         token = self.current_token
         if token.type == TokenType.INT:
             self.eat(TokenType.INT)
@@ -1080,9 +1111,9 @@ class Parser:
                     if self.current_token.type == TokenType.EOF:
                         self.incomplete_input()
                     self.skip_newline()
-                    k = self.expr()
+                    k = yield from self.expr()
                     self.eat(TokenType.COLON)
-                    v = self.expr()
+                    v = yield from self.expr()
                     items.append((k, v))
             self.skip_newline()
             self.eat(TokenType.RBRACE)
@@ -1133,7 +1164,7 @@ class Parser:
             while True:
                 if self.current_token.type == TokenType.FStringExpr:
                     self.eat(TokenType.FStringExpr)
-                    t = self.expr()
+                    t = yield from self.expr()
                     if not isinstance(t, String):
                         t = Call(
                             t.line,
@@ -1151,11 +1182,29 @@ class Parser:
                     self.eat(TokenType.FStringEnd)
                     break
                 else:
-                    t = self.expr()
+                    t = yield from self.expr()
                     out.append(t)
             if len(out) == 1:
+                yield ParserWarn(
+                    'Format string with no expressions',
+                    start_line,
+                    start_col,
+                    self.current_token.end_line,
+                    self.current_token.end_col,
+                    self.fp,
+                    self
+                )
                 return out[0]
             if len(out) == 0:
+                yield ParserWarn(
+                    'Empty format string',
+                    token.line,
+                    token.col,
+                    token.end_line,
+                    token.end_col,
+                    self.fp,
+                    self
+                )
                 return String(start_line, start_col, start_line, start_col + 1, '')
             rhs = out[1]
             for node in out[2:]:
@@ -1201,7 +1250,7 @@ class Parser:
             return Null(token.line, token.col, token.end_line, token.end_col)
         elif token.type == TokenType.LPAREN:
             self.eat(TokenType.LPAREN)
-            node = self.expr()
+            node = yield from self.expr()
             if self.current_token.type == TokenType.EOF:
                 self.incomplete_input()
             self.skip_newline()
@@ -1216,9 +1265,9 @@ class Parser:
             token.end_col,
         )
 
-    def export(self):
+    def export(self) -> Generator[ParserWarn, None, ASTNode]:
         self.eat(TokenType.EXPORT)
-        out = self.statement()
+        out = yield from self.statement()
         if out is None:
             raise ParserError(
                 3,
@@ -1249,7 +1298,7 @@ class Parser:
             name,
         )
 
-    def statement(self):
+    def statement(self) -> Generator[ParserWarn, None, ASTNode | None]:
         self.skip_newline()
         if self.current_token.type == TokenType.RBRACE:
             return None
@@ -1289,11 +1338,11 @@ class Parser:
                     reqs.append(req)
                     req = ''
                 if self.current_token.type == TokenType.LBRACE:
-                    blk = self.block()
+                    blk = yield from self.block()
                     else_block: Block | None = None
                     if self.current_token.type == TokenType.ELSE:
                         self.eat(TokenType.ELSE)
-                        else_block = self.block()
+                        else_block = yield from self.block()
                     return RequireStatement(
                         ln, col, blk.end_line, blk.end_col, reqs, blk, else_block
                     )
@@ -1302,15 +1351,16 @@ class Parser:
                         ln, col, self.current_token.line, self.current_token.col, reqs
                     )
         elif self.current_token.type == TokenType.LBRACE:
-            return self.block()
+            b = yield from self.block()
+            return b
         elif self.current_token.type == TokenType.FUNC:
-            return self.function_decl()
+            return (yield from self.function_decl())
         elif self.current_token.type == TokenType.IF:
-            return self.if_decl()
+            return (yield from self.if_decl())
         elif self.current_token.type == TokenType.EXPORT:
-            return self.export()
+            return (yield from self.export())
         elif self.current_token.type == TokenType.WHILE:
-            return self.while_decl()
+            return (yield from self.while_decl())
         elif self.current_token.type == TokenType.IMPORT:
             ln = self.current_token.line
             col = self.current_token.col
@@ -1325,7 +1375,7 @@ class Parser:
                 return Return(
                     ln, col, self.current_token.line, self.current_token.col, None
                 )
-            value = self.expr()
+            value = yield from self.expr()
             return Return(ln, col, value.end_line, value.end_col, value)
         elif self.current_token.type == TokenType.IDENTIFIER:
             next_tok = self.peek()
@@ -1334,7 +1384,7 @@ class Parser:
                 col = self.current_token.col
                 name = self.eat(TokenType.IDENTIFIER).value
                 self.eat(TokenType.ASSIGN)
-                value = self.expr()
+                value = yield from self.expr()
                 return Assign(ln, col, value.end_line, value.end_col, name, value)
             elif next_tok and next_tok.type in (
                 TokenType.PLUS_ASSIGN,
@@ -1364,7 +1414,7 @@ class Parser:
                         op_token.end_line,
                         op_token.end_col,
                     )
-                value = self.expr()
+                value = yield from self.expr()
                 return Assign(
                     ln,
                     col,
@@ -1381,26 +1431,27 @@ class Parser:
                         value,
                     ),
                 )
-        return self.expr()
+        e = yield from self.expr()
+        return e
 
-    def if_decl(self):
+    def if_decl(self) -> Generator[ParserWarn, None, If]:
         ln = self.current_token.line
         col = self.current_token.col
         self.eat(TokenType.IF)
-        expr = self.expr()
+        expr = yield from self.expr()
         if self.current_token.type == TokenType.EOF:
             self.incomplete_input()
         self.skip_newline()
-        body = self.block()
+        body = yield from self.block()
         if (
             self.current_token.type == TokenType.ELSE
             and self.peek().type == TokenType.IF
         ):
             self.eat(TokenType.ELSE)
-            else_body = self.if_decl()
+            else_body = yield from self.if_decl()
         elif self.current_token.type == TokenType.ELSE:
             self.eat(TokenType.ELSE)
-            else_body = self.block()
+            else_body = yield from self.block()
         else:
             else_body = None
         if else_body is None:
@@ -1415,14 +1466,14 @@ class Parser:
         ln = self.current_token.line
         col = self.current_token.col
         self.eat(TokenType.WHILE)
-        expr = self.expr()
+        expr = yield from self.expr()
         if self.current_token.type == TokenType.EOF:
             self.incomplete_input()
         self.skip_newline()
-        body = self.block()
+        body = yield from self.block()
         return While(ln, col, body.end_line, body.end_col, expr, body)
 
-    def function_decl(self):
+    def function_decl(self) -> Generator[ParserWarn, None, ASTNode]:
         ln = self.current_token.line
         col = self.current_token.col
         self.eat(TokenType.FUNC)
@@ -1446,7 +1497,7 @@ class Parser:
             if self.current_token.type == TokenType.ASSIGN:
                 optional = True
                 self.eat(TokenType.ASSIGN)
-                params[-1].option = self.primary()
+                params[-1].option = yield from self.primary()
                 params[-1].end_col = params[-1].option.end_col
                 params[-1].end_line = params[-1].option.end_line
             elif optional:
@@ -1473,7 +1524,7 @@ class Parser:
                 if self.current_token.type == TokenType.ASSIGN:
                     optional = True
                     self.eat(TokenType.ASSIGN)
-                    params[-1].option = self.primary()
+                    params[-1].option = yield from self.primary()
                     params[-1].end_col = self.current_token.col
                 elif optional:
                     raise ParserError(
@@ -1486,7 +1537,7 @@ class Parser:
                     )
         self.eat(TokenType.RPAREN)
 
-        body = self.block()
+        body = yield from self.block()
         return Assign(
             ln,
             col,
@@ -1503,7 +1554,7 @@ class Parser:
         return Token(TokenType.EOF, None, 0, 0, 0, 0)
 
     def parse(self):
-        node = self.statement()
+        node = yield from self.statement()
         if self.current_token.type != TokenType.EOF:
             raise ParserError(
                 3,
@@ -1515,13 +1566,13 @@ class Parser:
             )
         return node
 
-    def program(self):
+    def program(self) -> Generator[ParserWarn, None, Program]:
         statements: list = []
         while self.current_token.type != TokenType.EOF:
             if self.current_token.type == TokenType.NEWLINE:
                 self.eat(TokenType.NEWLINE)
                 continue
-            stmnt = self.statement()
+            stmnt = yield from self.statement()
             if stmnt is not None:
                 statements.append(stmnt)
             else:
@@ -1536,7 +1587,7 @@ class Parser:
                 break
         return Program(0, 0, end_line, end_col, statements)
 
-    def block(self):
+    def block(self) -> Generator[ParserWarn, None, Block]:
         self.eat(TokenType.LBRACE)
         statements = []
         line = self.current_token.line
@@ -1546,7 +1597,7 @@ class Parser:
             if self.current_token.type == TokenType.EOF:
                 self.incomplete_input()
                 break
-            stmnt = self.statement()
+            stmnt = yield from self.statement()
             if stmnt is not None:
                 statements.append(stmnt)
         if self.current_token.type == TokenType.EOF:
@@ -1687,7 +1738,7 @@ class Function(ASTNode):
 class If(ASTNode):
     expr: ASTNode
     body: Block
-    else_body: Block | None
+    else_body: Block | None | If
 
 
 @dataclass
@@ -1806,7 +1857,6 @@ class Compiler:
         self.req_stack: list[
             Compiler.RequirementGroup
         ] = []  # LIFO stack for nested @require statements
-        self.warns: list[str] = []
         self.req_stack_not_allowed: list[
             Compiler.RequirementGroup
         ] = []  # for errors when using a feature where it isn't allowed, like the else branch of an @require statement
@@ -1863,15 +1913,6 @@ class Compiler:
             self.next_local = len(self.var_map)
             self.args = args if args is not None else {}
 
-    @dataclass
-    class Warn:  # TODO: make a warning code
-        message: str
-        line: int
-        col: int
-        end_line: int
-        end_col: int
-        fp: str
-        compiler: Compiler
 
     @dataclass
     class Result:
@@ -1941,7 +1982,7 @@ class Compiler:
         program: Program,
         features: Collection[Literal['source'] | Literal['line']] = [],
         input_source: str | None = None,
-    ) -> Generator[Warn | ModuleRequest, ModuleReceived | None, list[str]]:
+    ) -> Generator[CompilerWarn | ModuleRequest, ModuleReceived | None, list[str]]:
         if input_source is None and 'source' in features:
             raise CompilerError(
                 8,
@@ -2023,7 +2064,7 @@ class Compiler:
             end_line = node.end_line
             if illegal:
                 if unsure:
-                    yield self.Warn(
+                    yield CompilerWarn(
                         f'CRITICAL: This may need the `{req}` requirement, and is in an illegal zone. Perhaps add `@require {req}` to the top of your program?',  # TODO: warning priorities
                         ln,
                         col,
@@ -2044,7 +2085,7 @@ class Compiler:
                     )
             else:
                 if unsure:
-                    yield self.Warn(
+                    yield CompilerWarn(
                         f'This may need the `{req}` requirement. Perhaps add `@require {req}` to the top of your program?',
                         ln,
                         col,
@@ -2055,7 +2096,7 @@ class Compiler:
                     )
                 else:
                     self.reqs.append(req)
-                    yield self.Warn(
+                    yield CompilerWarn(
                         f'{second_name} implicitly adds the `{req}` requirement. Perhaps add `@require {req}` to the top of your program to make it explicit?',
                         ln,
                         col,
@@ -2067,7 +2108,7 @@ class Compiler:
 
     def compile_ins(
         self, node: ASTNode, *other
-    ) -> Generator[Warn | ModuleRequest, ModuleReceived | None, Any]:
+    ) -> Generator[CompilerWarn | ModuleRequest, ModuleReceived | None, Any]:
         if isinstance(node, String):
             idx = self.add_constant([T_STRING, node.value])
             self.emit(node.line, OP_PUSH_CONST, idx)
@@ -2142,7 +2183,7 @@ class Compiler:
                     depth = 0
                 self.emit(node.line, OP_SET_VAR, idx, depth)
 
-                yield self.Warn(
+                yield CompilerWarn(
                     f'Reassignment to a function attempted for {node.name}(). This is usually not recommended',
                     node.line,
                     node.col,
@@ -2399,7 +2440,7 @@ class Compiler:
                                     yield from self.compile_ins(item.option)
                         self.emit(node.line, OpcodeType.CALL, len(params))
                     else:
-                        yield self.Warn(
+                        yield CompilerWarn(
                             'Could not detect how many min and max arguments for function call',
                             node.line,
                             node.col,
@@ -2527,7 +2568,7 @@ class Compiler:
             yield from self.raise_for_req('attributes', 'Attribute', 'Attributes', node)
             broken = False
             if 'types.dicts' in self.reqs:
-                yield self.Warn(
+                yield CompilerWarn(
                     'Dictionaries are enabled, so koniscript cannot check arguments or whether this attribute exists. This will be fixed once koniscript releases a proper type checker',
                     node.line,
                     node.col,

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -226,13 +226,8 @@ class Tokenizer:
         while self.get_current_char() is not None and self.get_current_char() != char:
             if self.get_current_char() == '\\':
                 self.advance()
-                match self.get_current_char():
-                    case 'n':
-                        value += '\n'
-                    case 't':
-                        value += '\t'
-                    case _:
-                        value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
+                value += self.parse_escape_seq(char)
+                #self.advance()
             else:
                 value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
             self.advance()
@@ -257,7 +252,9 @@ class Tokenizer:
                 self.get_current_char() is not None and self.get_current_char() != '`'
             ):
                 if self.get_current_char() == '\\':
+                    self.advance()
                     value += self.parse_escape_seq('`')
+                    self.advance()
                 elif self.check('${'):
                     self.advance(2)
                     self.mode_stack.append(self.TokenizerMode.FStringEpr)
@@ -334,13 +331,57 @@ class Tokenizer:
             self.advance()
         match self.get_current_char():
             case 'n':
-                return '\n'
+                to_ret = '\n'
             case 'r':
-                return '\r'
+                to_ret = '\r'
             case 't':
-                return '\t'
+                to_ret = '\t'
             case '\\':
-                return '\\'
+                to_ret = '\\'
+            case 'x':
+                self.advance()
+                c = self.get_current_char()
+                if c is None:
+                    raise TokenizerError(
+                        3,
+                        'Unexpected EOF when decoding escape code',
+                        self.line,
+                        self.col,
+                        self.line,
+                        self.col
+                    )
+                if ord(c.lower()) > 102:
+                    raise TokenizerError(
+                        17,
+                        'Invalid hexadecimal escape code',
+                        self.line,
+                        self.col,
+                        self.line,
+                        self.col+1
+                    )
+                self.advance()
+                tmp = self.get_current_char()
+                if tmp is None:
+                    raise TokenizerError(
+                        3,
+                        'Unexpected EOF when decoding escape code',
+                        self.line,
+                        self.col,
+                        self.line,
+                        self.col+1
+                    )
+                if ord(tmp.lower()) > 102:
+                    raise TokenizerError(
+                        17,
+                        'Invalid hexadecimal escape code',
+                        self.line,
+                        self.col,
+                        self.line,
+                        self.col+1
+                    )
+                c += tmp
+                input(self.get_current_char())
+                return chr(int(c, 16))
             case _:
                 if self.get_current_char() == char:
                     return char
@@ -352,6 +393,9 @@ class Tokenizer:
                     self.line,
                     self.col + 1,
                 )
+        #self.advance()
+        input(self.get_current_char())
+        return to_ret
 
     def get_next_token(self):  # sourcery skip: extract-method, low-code-quality
         start_line = self.line

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -840,14 +840,14 @@ class Parser:
         base_env: list[tuple],
         repl: bool = False,
         fp: str = '<unknown>',
-        file_content: str | None = None,
+        file_content: str = '<unknown>',
     ):
         self.base_env = base_env
         self.tokens = tokens
         self.pos = 0
         self.repl = repl
         self.fp = fp
-        self.file_content: str = '<unknown>'
+        self.file_content: str = file_content
         self.current_token = (
             self.tokens[0] if self.tokens else Token(TokenType.EOF, None, 0, 0, 0, 0)
         )

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -169,11 +169,16 @@ class FormatStringExpr(FormatStringComponent):
 
 
 class Tokenizer:
-    class TokenizerMode(Enum):
+    class Mode(Enum):
         Normal = auto()
         FStringEpr = auto()
         FStringStr = auto()
-        FStringMStr = auto() # multiline
+
+    @dataclass
+    class ModeState:
+        mode: Tokenizer.Mode
+        multiline: bool = False
+        raw: bool = False
 
     def __init__(self, string: str):
         self.string: str = string
@@ -182,7 +187,18 @@ class Tokenizer:
         self.col: int = 0
         # self.mode: Tokenizer.TokenizerMode = self.TokenizerMode.Normal
         self.fstring_count = 0
-        self.mode_stack: list[Tokenizer.TokenizerMode] = [self.TokenizerMode.Normal]
+        self.mode_stack: list[Tokenizer.ModeState] = [self.ModeState(self.Mode.Normal)]
+
+    def is_str_prefix(self):
+        i = 0
+        while True:
+            match self.peek(i):
+                case 'm' | 'r':
+                    i += 1
+                case '"' | "'" | '`':
+                    return True
+                case _:
+                    return False
 
     def advance(self, steps: int = 1) -> str | None:
         if steps <= 0:  # To make sure that `ch` isn't `Unbound`
@@ -212,9 +228,9 @@ class Tokenizer:
             else:
                 break
 
-    def peek(self):
-        if self.current_idx + 1 < len(self.string):
-            return self.string[self.current_idx + 1]
+    def peek(self, amnt: int = 1):
+        if self.current_idx + amnt < len(self.string):
+            return self.string[self.current_idx + amnt]
         else:
             return None
 
@@ -222,12 +238,19 @@ class Tokenizer:
         end = self.current_idx + len(text)
         return self.string[self.current_idx : end] == text
 
-    def tokenize_string(self, char: Literal["'", '"'], start_line, start_col, multiline: bool = False) -> Token:
+    def tokenize_string(
+        self,
+        char: Literal["'", '"'],
+        start_line,
+        start_col,
+        multiline: bool = False,
+        raw: bool = False,
+    ) -> Token:
         value = ''
         while self.get_current_char() is not None and self.get_current_char() != char:
             if not multiline and self.get_current_char() == '\n':
                 break
-            if self.get_current_char() == '\\':
+            if self.get_current_char() == '\\' and not raw:
                 self.advance()
                 value += self.parse_escape_seq(char)
                 # self.advance()
@@ -249,24 +272,25 @@ class Tokenizer:
         )
 
     def tokenize_format_string(
-        self, start_line, start_col, multiline: bool = True
+        self, start_line, start_col, multiline: bool = False, raw: bool = False
     ) -> Token | list[Token]:
-        if self.mode_stack[-1] in (self.TokenizerMode.FStringStr, self.TokenizerMode.FStringMStr):
+        if self.mode_stack[-1].mode == self.Mode.FStringStr:
             value = ''
             while (
-                self.get_current_char() is not None
-                and self.get_current_char() != '`'
+                self.get_current_char() is not None and self.get_current_char() != '`'
             ):
-                if self.mode_stack[-1] == self.TokenizerMode.FStringStr:
-                    if self.get_current_char() == '\n':
-                        break
-                if self.get_current_char() == '\\':
+                if (
+                    self.get_current_char() == '\n'
+                    and not self.mode_stack[-1].multiline
+                ):
+                    break
+                if self.get_current_char() == '\\' and not self.mode_stack[-1].raw:
                     self.advance()
                     value += self.parse_escape_seq('`')
                     self.advance()
                 elif self.check('${'):
                     self.advance(2)
-                    self.mode_stack.append(self.TokenizerMode.FStringEpr)
+                    self.mode_stack.append(self.ModeState(self.Mode.FStringEpr))
                     return [
                         Token(
                             TokenType.STRING,
@@ -323,17 +347,8 @@ class Tokenizer:
                 TokenType.FStringEnd, None, start_line, start_col, self.line, self.col
             )
 
-        # elif self.mode_stack[-1] == self.TokenizerMode.FStringEpr:
-        #    if self.get_current_char() == '}':
-        #        self.mode_stack.pop()
-        #        return Token(TokenType.FStringEnd, None, self.line, self.col, self.line, self.col)
-        #    return self.get_next_token()
         else:
-            if multiline:
-                out = self.TokenizerMode.FStringMStr
-            else:
-                out = self.TokenizerMode.FStringStr
-            self.mode_stack.append(out)
+            self.mode_stack.append(self.ModeState(self.Mode.FStringStr, multiline, raw))
             self.fstring_count += 1
             return Token(
                 TokenType.FStringStart, None, self.line, self.col, self.line, self.col
@@ -402,7 +417,7 @@ class Tokenizer:
                 return '\\'
             case 'b':
                 return '\b'
-            case '\n': # multi line strings
+            case '\n':  # multi line strings
                 return ''
             case 'f':
                 return '\f'
@@ -431,7 +446,7 @@ class Tokenizer:
     def get_next_token(self):  # sourcery skip: extract-method, low-code-quality
         start_line = self.line
         start_col = self.col
-        if self.mode_stack[-1] in (self.TokenizerMode.FStringStr, self.TokenizerMode.FStringMStr):
+        if self.mode_stack[-1].mode == self.Mode.FStringStr:
             return self.tokenize_format_string(start_line, start_col)
         self.skip_whitespace()
         current_char = self.get_current_char()
@@ -472,16 +487,31 @@ class Tokenizer:
                     self.line,
                     self.col,
                 )
-        elif current_char == 'm' and self.peek() in ('"', "'", '`'):
-            char = self.peek()
-            self.advance(2)
+        elif self.is_str_prefix():
+            raw = False
+            multiline = False
+            adv = 1
+            c = False
+            while True:
+                match self.get_current_char():
+                    case 'm':
+                        multiline = True
+                    case 'r':
+                        raw = True
+                    case _:
+                        break
+                self.advance()
+            char = self.get_current_char()
+            self.advance()
             match char:
-                case "'":
-                    return self.tokenize_string("'", start_line, start_col, True)
-                case '"':
-                    return self.tokenize_string('"', start_line, start_col, True)
+                case "'" | '"':
+                    return self.tokenize_string(
+                        char, start_line, start_col, multiline, raw
+                    )
                 case '`':
-                    return self.tokenize_format_string(start_line, start_col, True)
+                    return self.tokenize_format_string(
+                        start_line, start_col, multiline, raw
+                    )
         elif current_char == '[':
             self.advance(1)
             return Token(
@@ -615,7 +645,7 @@ class Tokenizer:
             )
         elif current_char == '}':
             self.advance(1)
-            if self.mode_stack[-1] == self.TokenizerMode.FStringEpr:
+            if self.mode_stack[-1].mode == self.Mode.FStringEpr:
                 self.mode_stack.pop()
                 return Token(
                     TokenType.FStringExprEnd,
@@ -1947,7 +1977,7 @@ class Compiler:
         output.append('.const')
         for const in self.constants:
             output.append(
-                f'{const[0]};{str(const[1]).replace("\n", "\\n").replace(";", "\\;")};'
+                f'{const[0]};{str(const[1]).replace("\\", "\\\\").replace("\n", "\\n").replace(";", "\\;")};'
             )
         output.append('.code')
         for instr in self.code:

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -224,7 +224,7 @@ class Tokenizer:
     def tokenize_string(self, char: Literal["'", '"'], start_line, start_col) -> Token:
         self.advance(1)
         value = ''
-        while self.get_current_char() is not None and self.get_current_char() != char:
+        while self.get_current_char() is not None and self.get_current_char() != char and self.get_current_char() != '\n':
             if self.get_current_char() == '\\':
                 self.advance()
                 value += self.parse_escape_seq(char)
@@ -239,7 +239,7 @@ class Tokenizer:
                 start_line,
                 start_col,
                 self.line,
-                self.col,
+                self.col + 1,
             )
         self.advance()
         return Token(
@@ -250,7 +250,7 @@ class Tokenizer:
         if self.mode_stack[-1] == self.TokenizerMode.FStringStr:
             value = ''
             while (
-                self.get_current_char() is not None and self.get_current_char() != '`'
+                self.get_current_char() is not None and self.get_current_char() != '`' and self.get_current_char() != '\n'
             ):
                 if self.get_current_char() == '\\':
                     self.advance()

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -173,6 +173,7 @@ class Tokenizer:
         Normal = auto()
         FStringEpr = auto()
         FStringStr = auto()
+        FStringMStr = auto() # multiline
 
     def __init__(self, string: str):
         self.string: str = string
@@ -221,10 +222,11 @@ class Tokenizer:
         end = self.current_idx + len(text)
         return self.string[self.current_idx : end] == text
 
-    def tokenize_string(self, char: Literal["'", '"'], start_line, start_col) -> Token:
-        self.advance(1)
+    def tokenize_string(self, char: Literal["'", '"'], start_line, start_col, multiline: bool = False) -> Token:
         value = ''
-        while self.get_current_char() is not None and self.get_current_char() != char and self.get_current_char() != '\n':
+        while self.get_current_char() is not None and self.get_current_char() != char:
+            if not multiline and self.get_current_char() == '\n':
+                break
             if self.get_current_char() == '\\':
                 self.advance()
                 value += self.parse_escape_seq(char)
@@ -246,12 +248,18 @@ class Tokenizer:
             TokenType.STRING, value, start_line, start_col, self.line, self.col
         )
 
-    def tokenize_format_string(self, start_line, start_col) -> Token | list[Token]:
-        if self.mode_stack[-1] == self.TokenizerMode.FStringStr:
+    def tokenize_format_string(
+        self, start_line, start_col, multiline: bool = True
+    ) -> Token | list[Token]:
+        if self.mode_stack[-1] in (self.TokenizerMode.FStringStr, self.TokenizerMode.FStringMStr):
             value = ''
             while (
-                self.get_current_char() is not None and self.get_current_char() != '`' and self.get_current_char() != '\n'
+                self.get_current_char() is not None
+                and self.get_current_char() != '`'
             ):
+                if self.mode_stack[-1] == self.TokenizerMode.FStringStr:
+                    if self.get_current_char() == '\n':
+                        break
                 if self.get_current_char() == '\\':
                     self.advance()
                     value += self.parse_escape_seq('`')
@@ -321,7 +329,11 @@ class Tokenizer:
         #        return Token(TokenType.FStringEnd, None, self.line, self.col, self.line, self.col)
         #    return self.get_next_token()
         else:
-            self.mode_stack.append(self.TokenizerMode.FStringStr)
+            if multiline:
+                out = self.TokenizerMode.FStringMStr
+            else:
+                out = self.TokenizerMode.FStringStr
+            self.mode_stack.append(out)
             self.fstring_count += 1
             return Token(
                 TokenType.FStringStart, None, self.line, self.col, self.line, self.col
@@ -390,6 +402,8 @@ class Tokenizer:
                 return '\\'
             case 'b':
                 return '\b'
+            case '\n': # multi line strings
+                return ''
             case 'f':
                 return '\f'
             case 'e':
@@ -417,7 +431,7 @@ class Tokenizer:
     def get_next_token(self):  # sourcery skip: extract-method, low-code-quality
         start_line = self.line
         start_col = self.col
-        if self.mode_stack[-1] == self.TokenizerMode.FStringStr:
+        if self.mode_stack[-1] in (self.TokenizerMode.FStringStr, self.TokenizerMode.FStringMStr):
             return self.tokenize_format_string(start_line, start_col)
         self.skip_whitespace()
         current_char = self.get_current_char()
@@ -458,6 +472,16 @@ class Tokenizer:
                     self.line,
                     self.col,
                 )
+        elif current_char == 'm' and self.peek() in ('"', "'", '`'):
+            char = self.peek()
+            self.advance(2)
+            match char:
+                case "'":
+                    return self.tokenize_string("'", start_line, start_col, True)
+                case '"':
+                    return self.tokenize_string('"', start_line, start_col, True)
+                case '`':
+                    return self.tokenize_format_string(start_line, start_col, True)
         elif current_char == '[':
             self.advance(1)
             return Token(
@@ -592,7 +616,6 @@ class Tokenizer:
         elif current_char == '}':
             self.advance(1)
             if self.mode_stack[-1] == self.TokenizerMode.FStringEpr:
-                # self.mode = self.TokenizerMode.FStringStr
                 self.mode_stack.pop()
                 return Token(
                     TokenType.FStringExprEnd,
@@ -632,8 +655,10 @@ class Tokenizer:
                 TokenType.GREATER_THAN, None, start_line, start_col, self.line, self.col
             )
         elif current_char == '"':
+            self.advance()
             return self.tokenize_string('"', start_line, start_col)
         elif current_char == "'":
+            self.advance()
             return self.tokenize_string("'", start_line, start_col)
         elif current_char == '`':
             self.advance()
@@ -1099,15 +1124,9 @@ class Parser:
                     t = self.expr()
                     out.append(t)
             if len(out) == 1:
-                # raise ParserWarn( # TODO: Make parser warnings
-                #     18,
-                #     'Format string without any expressions',
-                #     start_line,
-                #     start_col,
-                #     self.current_token.line,
-                #     self.current_token.col
-                # )
                 return out[0]
+            if len(out) == 0:
+                return String(start_line, start_col, start_line, start_col + 1, '')
             rhs = out[1]
             for node in out[2:]:
                 rhs = BinOp(

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -76,7 +76,7 @@ class TokenType(Enum):
     FStringStart = 'FStringStart'
     FStringExpr = 'FStringExpr'
     FStringExprEnd = 'FStringExprEnd'
-    FStringEnd = 'FstringEnd'
+    FStringEnd = 'FStringEnd'
 
 
 PRECEDENCE = {
@@ -407,7 +407,7 @@ class Tokenizer:
                         self.fp,
                         self.string,
                     )
-                if hex_check(c):
+                if hex_check(tmp):
                     raise TokenizerError(
                         17,
                         'Invalid hexadecimal escape code',

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -92,31 +92,28 @@ PRECEDENCE = {
 class CompilationException(Exception):
     code: int
     msg: str
-    line: int | None
-    col: int | None
-    end_line: int | None
-    end_col: int | None
-
-
-@dataclass
-class ParserError(CompilationException):
-    line: int  # type: ignore[override]
-    col: int  # type: ignore[override]
-    end_line: int  # type: ignore[override]
-    end_col: int  # type: ignore[override]
-
-
-@dataclass
-class CompilerError(CompilationException):
+    line: int
+    col: int
+    end_line: int
+    end_col: int
     fp: str
 
 
 @dataclass
+class ParserError(CompilationException):
+    file_content: str
+    pass
+
+
+@dataclass
+class CompilerError(CompilationException):
+    pass
+
+
+@dataclass
 class TokenizerError(CompilationException):
-    line: int  # type: ignore[override]
-    col: int  # type: ignore[override]
-    end_line: int  # type: ignore[override]
-    end_col: int  # type: ignore[override]
+    file_content: str
+    pass
 
 
 KEYWORDS = {
@@ -180,11 +177,12 @@ class Tokenizer:
         multiline: bool = False
         raw: bool = False
 
-    def __init__(self, string: str):
+    def __init__(self, string: str, fp: str = '<unknown>'):
         self.string: str = string
         self.current_idx: int = 0
         self.line: int = 0
         self.col: int = 0
+        self.fp: str = fp
         # self.mode: Tokenizer.TokenizerMode = self.TokenizerMode.Normal
         self.fstring_count = 0
         self.mode_stack: list[Tokenizer.ModeState] = [self.ModeState(self.Mode.Normal)]
@@ -265,6 +263,8 @@ class Tokenizer:
                 start_col,
                 self.line,
                 self.col + 1,
+                self.fp,
+                self.string,
             )
         self.advance()
         return Token(
@@ -320,6 +320,8 @@ class Tokenizer:
                     start_col,
                     self.line,
                     self.col + 1,
+                    self.fp,
+                    self.string,
                 )
 
             self.advance()
@@ -351,7 +353,12 @@ class Tokenizer:
             self.mode_stack.append(self.ModeState(self.Mode.FStringStr, multiline, raw))
             self.fstring_count += 1
             return Token(
-                TokenType.FStringStart, None, self.line, self.col, self.line, self.col
+                TokenType.FStringStart,
+                None,
+                self.line,
+                self.col - 1,
+                self.line,
+                self.col,
             )
 
     def parse_escape_seq(self, char: Literal['"', "'", '`']):
@@ -372,6 +379,8 @@ class Tokenizer:
                     self.col,
                     self.line,
                     self.col,
+                    self.fp,
+                    self.string,
                 )
             if hex_check(c):
                 raise TokenizerError(
@@ -381,6 +390,8 @@ class Tokenizer:
                     self.col,
                     self.line,
                     self.col + 1,
+                    self.fp,
+                    self.string,
                 )
             for _ in range(amnt - 1):
                 self.advance()
@@ -393,6 +404,8 @@ class Tokenizer:
                         self.col,
                         self.line,
                         self.col + 1,
+                        self.fp,
+                        self.string,
                     )
                 if hex_check(c):
                     raise TokenizerError(
@@ -402,6 +415,8 @@ class Tokenizer:
                         self.col,
                         self.line,
                         self.col + 1,
+                        self.fp,
+                        self.string,
                     )
                 c += tmp
             return chr(int(c, 16))
@@ -441,6 +456,8 @@ class Tokenizer:
                     self.col,
                     self.line,
                     self.col + 1,
+                    self.fp,
+                    self.string,
                 )
 
     def get_next_token(self):  # sourcery skip: extract-method, low-code-quality
@@ -713,6 +730,8 @@ class Tokenizer:
             self.col,
             self.line,
             self.col + 1,
+            self.fp,
+            self.string,
         )
 
 
@@ -792,6 +811,8 @@ class BinOpType(Enum):
 class UnaryOpType(Enum):
     NEG = 'NEG'
     NOT = TokenType.NOT
+
+
 @dataclass
 class Warn:  # TODO: make a warning code
     message: str
@@ -805,19 +826,28 @@ class Warn:  # TODO: make a warning code
 @dataclass
 class ParserWarn(Warn):  # TODO: make a warning code
     parser: Parser
-    
+
+
 @dataclass
 class CompilerWarn(Warn):
     compiler: Compiler
 
+
 class Parser:
-    def __init__(self, tokens: list[Token], base_env: list[tuple], repl: bool = False, fp: str = '<unknown>', file_content: str| None =None):
+    def __init__(
+        self,
+        tokens: list[Token],
+        base_env: list[tuple],
+        repl: bool = False,
+        fp: str = '<unknown>',
+        file_content: str | None = None,
+    ):
         self.base_env = base_env
         self.tokens = tokens
         self.pos = 0
         self.repl = repl
         self.fp = fp
-        self.file_content: str | None = file_content
+        self.file_content: str = '<unknown>'
         self.current_token = (
             self.tokens[0] if self.tokens else Token(TokenType.EOF, None, 0, 0, 0, 0)
         )
@@ -836,6 +866,8 @@ class Parser:
                 self.current_token.col,
                 self.current_token.end_line,
                 self.current_token.end_col,
+                self.fp,
+                self.file_content,
             )
         self.advance()
         return out
@@ -1030,6 +1062,8 @@ class Parser:
                         self.current_token.col,
                         self.current_token.end_line,
                         self.current_token.end_col,
+                        self.fp,
+                        self.file_content,
                     )
 
                 end_tok = self.eat(TokenType.IDENTIFIER)
@@ -1192,7 +1226,7 @@ class Parser:
                     self.current_token.end_line,
                     self.current_token.end_col,
                     self.fp,
-                    self
+                    self,
                 )
                 return out[0]
             if len(out) == 0:
@@ -1203,7 +1237,7 @@ class Parser:
                     token.end_line,
                     token.end_col,
                     self.fp,
-                    self
+                    self,
                 )
                 return String(start_line, start_col, start_line, start_col + 1, '')
             rhs = out[1]
@@ -1263,6 +1297,8 @@ class Parser:
             token.col,
             token.end_line,
             token.end_col,
+            self.fp,
+            self.file_content,
         )
 
     def export(self) -> Generator[ParserWarn, None, ASTNode]:
@@ -1276,6 +1312,8 @@ class Parser:
                 self.current_token.col,
                 self.current_token.end_line,
                 self.current_token.end_col,
+                self.fp,
+                self.file_content,
             )
         if not isinstance(out, Assign):
             raise ParserError(
@@ -1285,6 +1323,8 @@ class Parser:
                 out.col,
                 self.current_token.end_line,
                 self.current_token.end_col,
+                self.fp,
+                self.file_content,
             )
         name = out.name
         ln = out.line
@@ -1413,6 +1453,8 @@ class Parser:
                         op_token.col,
                         op_token.end_line,
                         op_token.end_col,
+                        self.fp,
+                        self.file_content,
                     )
                 value = yield from self.expr()
                 return Assign(
@@ -1508,6 +1550,8 @@ class Parser:
                     self.current_token.col,
                     self.current_token.end_line,
                     self.current_token.end_col,
+                    self.fp,
+                    self.file_content,
                 )
             while self.current_token.type == TokenType.COMMA:
                 self.eat(TokenType.COMMA)
@@ -1534,6 +1578,8 @@ class Parser:
                         self.current_token.col,
                         self.current_token.end_line,
                         self.current_token.end_col,
+                        self.fp,
+                        self.file_content,
                     )
         self.eat(TokenType.RPAREN)
 
@@ -1563,6 +1609,8 @@ class Parser:
                 self.current_token.col,
                 self.current_token.end_line,
                 self.current_token.end_col,
+                self.fp,
+                self.file_content,
             )
         return node
 
@@ -1913,7 +1961,6 @@ class Compiler:
             self.next_local = len(self.var_map)
             self.args = args if args is not None else {}
 
-
     @dataclass
     class Result:
         value: str
@@ -1984,13 +2031,19 @@ class Compiler:
         input_source: str | None = None,
     ) -> Generator[CompilerWarn | ModuleRequest, ModuleReceived | None, list[str]]:
         if input_source is None and 'source' in features:
+            if len(program.statements) == 0:
+                end_line = 0
+                end_col = 0
+            else:
+                end_line = program.statements[-1].end_line
+                end_col = program.statements[-1].end_col
             raise CompilerError(
                 8,
                 'Compiler needs input source to compile with source info.',
-                None,
-                None,
-                None,
-                None,
+                0,
+                0,
+                end_line,
+                end_col,
                 self.mod_stack[-1].fp,
             )
         if 'source' in features:
@@ -2536,10 +2589,10 @@ class Compiler:
                 raise CompilerError(
                     13,
                     '(internal) Expected array `other` to have at least 1 value, found 0. This error should not be raised under any circumstance, please report at https://github.com/DELOLCAT/koniscript.',
-                    None,
-                    None,
-                    None,
-                    None,
+                    node.line,
+                    node.col,
+                    node.end_line,
+                    node.end_col,
                     self.mod_stack[-1].fp,
                 )
         elif isinstance(node, Return):

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -15,6 +15,7 @@ from koni_compiler.runtime import (
 )
 from enum import Enum, auto
 
+
 class TokenType(Enum):
     ADD = 'ADD'
     INTEGER = 'INT'
@@ -227,7 +228,7 @@ class Tokenizer:
             if self.get_current_char() == '\\':
                 self.advance()
                 value += self.parse_escape_seq(char)
-                #self.advance()
+                # self.advance()
             else:
                 value += self.get_current_char()  # pyright: ignore[reportOperatorIssue]
             self.advance()
@@ -329,19 +330,42 @@ class Tokenizer:
     def parse_escape_seq(self, char: Literal['"', "'", '`']):
         if self.get_current_char() == '\\':
             self.advance()
+
         def hex_tokenize(amnt: int):
-                def hex_check(c: str):
-                    return c[0].lower() not in '0123456789abcdef'
+            def hex_check(c: str):
+                return c[0].lower() not in '0123456789abcdef'
+
+            self.advance()
+            c = self.get_current_char()
+            if c is None:
+                raise TokenizerError(
+                    3,
+                    'Unexpected EOF when decoding escape code',
+                    self.line,
+                    self.col,
+                    self.line,
+                    self.col,
+                )
+            if hex_check(c):
+                raise TokenizerError(
+                    17,
+                    'Invalid hexadecimal escape code',
+                    self.line,
+                    self.col,
+                    self.line,
+                    self.col + 1,
+                )
+            for _ in range(amnt - 1):
                 self.advance()
-                c = self.get_current_char()
-                if c is None:
+                tmp = self.get_current_char()
+                if tmp is None:
                     raise TokenizerError(
                         3,
                         'Unexpected EOF when decoding escape code',
                         self.line,
                         self.col,
                         self.line,
-                        self.col
+                        self.col + 1,
                     )
                 if hex_check(c):
                     raise TokenizerError(
@@ -350,46 +374,34 @@ class Tokenizer:
                         self.line,
                         self.col,
                         self.line,
-                        self.col+1
+                        self.col + 1,
                     )
-                for _ in range(amnt - 1):
-                    self.advance()
-                    tmp = self.get_current_char()
-                    if tmp is None:
-                        raise TokenizerError(
-                            3,
-                            'Unexpected EOF when decoding escape code',
-                            self.line,
-                            self.col,
-                            self.line,
-                            self.col+1
-                        )
-                    if hex_check(c):
-                        raise TokenizerError(
-                            17,
-                            'Invalid hexadecimal escape code',
-                            self.line,
-                            self.col,
-                            self.line,
-                            self.col+1
-                        )
-                    c += tmp
-                return chr(int(c, 16))
+                c += tmp
+            return chr(int(c, 16))
 
         match self.get_current_char():
             case 'n':
-                to_ret = '\n'
+                return '\n'
             case 'r':
-                to_ret = '\r'
+                return '\r'
             case 't':
-                to_ret = '\t'
+                return '\t'
             case '\\':
-                to_ret = '\\'
-            case 'x':                
+                return '\\'
+            case 'b':
+                return '\b'
+            case 'f':
+                return '\f'
+            case 'e':
+                return '\x1b'
+            case 'a':
+                return '\x07'
+            case 'x':
                 return hex_tokenize(2)
-            case 'u' | 'U':
-                r = 4 if self.get_current_char() == 'u' else 8
-                return hex_tokenize(r)
+            case 'u':
+                return hex_tokenize(4)
+            case 'U':
+                return hex_tokenize(8)
             case _:
                 if self.get_current_char() == char:
                     return char
@@ -401,7 +413,6 @@ class Tokenizer:
                     self.line,
                     self.col + 1,
                 )
-        return to_ret
 
     def get_next_token(self):  # sourcery skip: extract-method, low-code-quality
         start_line = self.line

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -329,16 +329,9 @@ class Tokenizer:
     def parse_escape_seq(self, char: Literal['"', "'", '`']):
         if self.get_current_char() == '\\':
             self.advance()
-        match self.get_current_char():
-            case 'n':
-                to_ret = '\n'
-            case 'r':
-                to_ret = '\r'
-            case 't':
-                to_ret = '\t'
-            case '\\':
-                to_ret = '\\'
-            case 'x':
+        def hex_tokenize(amnt: int):
+                def hex_check(c: str):
+                    return c[0].lower() not in '0123456789abcdef'
                 self.advance()
                 c = self.get_current_char()
                 if c is None:
@@ -350,7 +343,7 @@ class Tokenizer:
                         self.line,
                         self.col
                     )
-                if ord(c.lower()) > 102:
+                if hex_check(c):
                     raise TokenizerError(
                         17,
                         'Invalid hexadecimal escape code',
@@ -359,29 +352,44 @@ class Tokenizer:
                         self.line,
                         self.col+1
                     )
-                self.advance()
-                tmp = self.get_current_char()
-                if tmp is None:
-                    raise TokenizerError(
-                        3,
-                        'Unexpected EOF when decoding escape code',
-                        self.line,
-                        self.col,
-                        self.line,
-                        self.col+1
-                    )
-                if ord(tmp.lower()) > 102:
-                    raise TokenizerError(
-                        17,
-                        'Invalid hexadecimal escape code',
-                        self.line,
-                        self.col,
-                        self.line,
-                        self.col+1
-                    )
-                c += tmp
-                input(self.get_current_char())
+                for _ in range(amnt - 1):
+                    self.advance()
+                    tmp = self.get_current_char()
+                    if tmp is None:
+                        raise TokenizerError(
+                            3,
+                            'Unexpected EOF when decoding escape code',
+                            self.line,
+                            self.col,
+                            self.line,
+                            self.col+1
+                        )
+                    if hex_check(c):
+                        raise TokenizerError(
+                            17,
+                            'Invalid hexadecimal escape code',
+                            self.line,
+                            self.col,
+                            self.line,
+                            self.col+1
+                        )
+                    c += tmp
                 return chr(int(c, 16))
+
+        match self.get_current_char():
+            case 'n':
+                to_ret = '\n'
+            case 'r':
+                to_ret = '\r'
+            case 't':
+                to_ret = '\t'
+            case '\\':
+                to_ret = '\\'
+            case 'x':                
+                return hex_tokenize(2)
+            case 'u' | 'U':
+                r = 4 if self.get_current_char() == 'u' else 8
+                return hex_tokenize(r)
             case _:
                 if self.get_current_char() == char:
                     return char
@@ -393,8 +401,6 @@ class Tokenizer:
                     self.line,
                     self.col + 1,
                 )
-        #self.advance()
-        input(self.get_current_char())
         return to_ret
 
     def get_next_token(self):  # sourcery skip: extract-method, low-code-quality


### PR DESCRIPTION
Checklist:
- [x] Add format strings, resolves #48 
- [x] Add more escape codes, like ones for hexadecimal characters
- [x] Make sure that strings stay on the same line
- [x] Make multiline strings with `m"string"`, `m'string'`, or m`format string`
- [x] Make some changes to the Platform Files spec about conversion methods
- [x] Add raw strings, resolves #49 
- [x] Add parser warnings
- [x] Make parser warnings, errors, and tokenizer errors aware of the filepath

## Summary by Sourcery

Add support for backtick-based format strings with embedded expressions and improve string tokenization and error reporting across the compiler and LSP.

New Features:
- Introduce backtick-delimited format strings with `${}` expressions that are converted to strings and concatenated at parse time.

Enhancements:
- Refactor string tokenization to share escape-sequence handling and add tokenizer modes for parsing format string text and expressions.
- Update the parser and AST to recognize format-string-specific tokens and construct concatenated string expressions.
- Adjust the compiler front end and LSP server to handle the tokenizer returning multiple tokens for parts of a single format string.

Documentation:
- Document new tokenizer error codes for unterminated format-string expressions and invalid escape sequences in the user-facing error reference.

## Summary by Sourcery

Add rich string literal support, including format and raw strings, and make compiler/parser/tokenizer errors and warnings file-aware while improving diagnostics integration in the CLI and LSP.

New Features:
- Introduce backtick-delimited format strings with `${}` expressions that are parsed into concatenated string expressions.
- Support multiline and raw string literals via `m` and `r` prefixes across single, double, and backtick-quoted strings.

Enhancements:
- Refactor tokenizer to centralize string and escape-sequence handling, add modes for format string text and expressions, and extend token types for format-string parsing.
- Convert the parser to a warning-emitting generator, adding structured parser and compiler warning types and plumbing them through the compiler, CLI, and LSP.
- Ensure string literals cannot implicitly span lines unless explicitly marked multiline, and improve constant encoding for backslashes and newlines in the output format.
- Extend error and warning structures to always carry file path and content information, improving source-range reporting.

Documentation:
- Document new tokenizer error codes for unterminated format-string expressions and invalid escape sequences.
- Clarify the platform file spec to define a string-conversion function used by format strings and describe behavior when it is missing.
- Update the VS Code extension README to describe the koniscript language support extension more clearly.