### PR TITLE
Add negative indexes

### DIFF
--- a/kovm/src/runtime.rs
+++ b/kovm/src/runtime.rs
@@ -409,6 +409,7 @@ pub enum ErrCode {
     InvalidOperation = 16,
     IndexError = 17,
     MathError = 18,
+    OverflowError = 19
 }
 impl fmt::Display for ErrCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/kovm/src/vm.rs
+++ b/kovm/src/vm.rs
@@ -809,7 +809,7 @@ impl VM {
                             Value::Integer(v) => {
                                 if v < 0 {
                                     let abs = v.abs() as usize;
-                                    let len = s.len();
+                                    let len = s.chars().count();
                                     if abs > len {
                                         return Err(VmError {
                                             msg: format!("Index {} out of bounds", v),

--- a/kovm/src/vm.rs
+++ b/kovm/src/vm.rs
@@ -753,12 +753,10 @@ impl VM {
                                     let abs = v.abs() as usize;
                                     let len = arr.borrow().len();
                                     if abs > len {
-                                        return Err(
-                                            VmError {
-                                                msg: format!("Index {} out of bounds", v),
-                                                errcode: ErrCode::IndexError
-                                            }
-                                        );
+                                        return Err(VmError {
+                                            msg: format!("Index {} out of bounds", v),
+                                            errcode: ErrCode::IndexError,
+                                        });
                                     }
                                     len - abs
                                 } else {
@@ -768,7 +766,7 @@ impl VM {
                             _ => {
                                 return Err(VmError {
                                     msg: format!(
-                                        "Cannot index an array with type `{}`",
+                                        "Cannot index into an array with type `{}`",
                                         rhs.display()
                                     ),
                                     errcode: ErrCode::TypeError,
@@ -799,23 +797,38 @@ impl VM {
                         Err(_) => unreachable!(),
                     },
                     Value::String(s) => {
-                        let rhs = match rhs {
-                            Value::Integer(v) => v,
+                        let idx = match rhs {
+                            Value::Integer(v) => {
+                                if v < 0 {
+                                    let abs = v.abs() as usize;
+                                    let len = s.len();
+                                    if abs > len {
+                                        return Err(VmError {
+                                            msg: format!("Index {} out of bounds", v),
+                                            errcode: ErrCode::IndexError,
+                                        });
+                                    }
+                                    len - abs
+                                } else {
+                                    v as usize
+                                }
+                            }
                             _ => {
                                 return Err(VmError {
                                     msg: format!(
-                                        "Cannot index into a string with type {}",
+                                        "Cannot index a string with type `{}`",
                                         rhs.display()
                                     ),
                                     errcode: ErrCode::TypeError,
                                 });
                             }
                         };
-                        let out = match s.chars().nth(rhs as usize) {
+
+                        let out = match s.chars().nth(idx as usize) {
                             Some(v) => Value::String(Rc::new(v.to_string())),
                             None => {
                                 return Err(VmError {
-                                    msg: format!("Index {} out of range", rhs),
+                                    msg: format!("Index {} out of range", idx),
                                     errcode: ErrCode::IndexError,
                                 });
                             }
@@ -824,7 +837,7 @@ impl VM {
                     }
                     _ => {
                         return Err(VmError {
-                            msg: format!("Cannot get an index from a {}", item.display()),
+                            msg: format!("Cannot get an index from type `{}`", item.display()),
                             errcode: ErrCode::TypeError,
                         });
                     }

--- a/kovm/src/vm.rs
+++ b/kovm/src/vm.rs
@@ -748,7 +748,23 @@ impl VM {
                 match item {
                     Value::Array(arr) => {
                         let idx = match rhs {
-                            Value::Integer(v) => v,
+                            Value::Integer(v) => {
+                                if v < 0 {
+                                    let abs = v.abs() as usize;
+                                    let len = arr.borrow().len();
+                                    if abs > len {
+                                        return Err(
+                                            VmError {
+                                                msg: format!("Index {} out of bounds", v),
+                                                errcode: ErrCode::IndexError
+                                            }
+                                        );
+                                    }
+                                    len - abs
+                                } else {
+                                    v as usize
+                                }
+                            }
                             _ => {
                                 return Err(VmError {
                                     msg: format!(
@@ -759,7 +775,8 @@ impl VM {
                                 });
                             }
                         };
-                        match arr.borrow().get::<usize>((idx).try_into().unwrap()) {
+
+                        match arr.borrow().get::<usize>(idx as usize) {
                             Some(v) => self.push_to_stack(v.clone()),
                             None => {
                                 return Err(VmError {
@@ -784,28 +801,26 @@ impl VM {
                     Value::String(s) => {
                         let rhs = match rhs {
                             Value::Integer(v) => v,
-                            _ => return Err(
-                                VmError {
-                                    msg: format!("Cannot index into a string with type {}", rhs.display()),
-                                    errcode: ErrCode::TypeError
-                                }
-                            )
+                            _ => {
+                                return Err(VmError {
+                                    msg: format!(
+                                        "Cannot index into a string with type {}",
+                                        rhs.display()
+                                    ),
+                                    errcode: ErrCode::TypeError,
+                                });
+                            }
                         };
                         let out = match s.chars().nth(rhs as usize) {
-                            Some(v) => {
-                                Value::String(Rc::new(v.to_string()))
-                            },
+                            Some(v) => Value::String(Rc::new(v.to_string())),
                             None => {
-                                return Err(
-                                    VmError {
-                                        msg: format!("Index {} out of range", rhs),
-                                        errcode: ErrCode::IndexError
-                                    }
-                                )
+                                return Err(VmError {
+                                    msg: format!("Index {} out of range", rhs),
+                                    errcode: ErrCode::IndexError,
+                                });
                             }
                         };
                         self.push_to_stack(out);
-                        
                     }
                     _ => {
                         return Err(VmError {
@@ -946,10 +961,7 @@ impl VM {
                     Value::Integer(val) => Value::Integer(0 - val),
                     _ => {
                         return Err(VmError {
-                            msg: format!(
-                                "Cannot convert a {} to a negative value",
-                                v.display()
-                            ),
+                            msg: format!("Cannot convert a {} to a negative value", v.display()),
                             errcode: ErrCode::TypeError,
                         });
                     }

--- a/kovm/src/vm.rs
+++ b/kovm/src/vm.rs
@@ -750,7 +750,15 @@ impl VM {
                         let idx = match rhs {
                             Value::Integer(v) => {
                                 if v < 0 {
-                                    let abs = v.abs() as usize;
+                                    let abs = match v.checked_abs() {
+                                        Some(v) => v as usize,
+                                        None => return Err(
+                                            VmError {
+                                                msg: "Integer overflow".into(),
+                                                errcode: ErrCode::OverflowError
+                                            }
+                                        )
+                                    };
                                     let len = arr.borrow().len();
                                     if abs > len {
                                         return Err(VmError {

--- a/specs/documentation/errors.md
+++ b/specs/documentation/errors.md
@@ -356,3 +356,7 @@ Used during certain calculations when they are mathematically impossible or unde
 ```koniscript
 println(5/0) # <- Attempted to divide by 0
 ```
+
+### 19: OverflowError
+
+Used whenever an integer overflows


### PR DESCRIPTION
Add negative indexes:

```
a = ['a', 'b', 'c']
println(a[-1]) # -> c

a = 'abc'
println(a[-1]) # -> c
```

## Summary by Sourcery

Support negative indexing for arrays and strings in the VM and tighten related index/type error handling.

New Features:
- Allow arrays to be indexed from the end using negative integer indices.
- Allow strings to be indexed from the end using negative integer indices.

Bug Fixes:
- Return clearer, more consistent error messages for invalid index types and out-of-bounds accesses in array and string indexing.

Enhancements:
- Standardize wording of type error messages for indexing operations and negative conversion errors.