### PR TITLE
Implement `SETITEM` and `SETATTR`

### DIFF
--- a/kovm/src/runtime.rs
+++ b/kovm/src/runtime.rs
@@ -121,8 +121,48 @@ pub enum Value {
     Array(Rc<RefCell<Vec<Value>>>),
     Null,
     RuntimeValue(RuntimeType),
-    Dict(Rc<Vec<(Value, Value)>>),
+    Dict(Rc<RefCell<Vec<(Value, Value)>>>),
     CallRequest(Rc<KoniFunc>, Rc<Vec<Value>>),
+}
+pub fn arr_idx_resolve(idx: &Value, arr: &Rc<RefCell<Vec<Value>>>) -> Result<usize, VmError> {
+    match idx {
+        Value::Integer(v) => {
+            if *v < 0 {
+                let abs = match v.checked_abs() {
+                    Some(v) => v as usize,
+                    None => {
+                        return Err(VmError {
+                            msg: "Integer overflow".into(),
+                            errcode: ErrCode::OverflowError,
+                        });
+                    }
+                };
+                let len = arr.borrow().len();
+                if abs > len {
+                    return Err(VmError {
+                        msg: format!("Index {} out of bounds", v),
+                        errcode: ErrCode::IndexError,
+                    });
+                }
+                Ok(len - abs)
+            } else {
+                let out = *v as usize;
+                if out >= arr.borrow().len() {
+                    return Err(VmError {
+                        msg: format!("Index {} out of bounds", v),
+                        errcode: ErrCode::IndexError,
+                    });
+                }
+                Ok(out)
+            }
+        }
+        _ => {
+            return Err(VmError {
+                msg: format!("Cannot index into an array with type `{}`", idx.display()),
+                errcode: ErrCode::TypeError,
+            });
+        }
+    }
 }
 fn eq_helper(a: &Value, other: &Value) -> Result<bool, ()> {
     match (a, other) {
@@ -188,7 +228,7 @@ impl Value {
                         return Err(VmError {
                             msg: format!("Invalid int `{}`", payload),
                             errcode: ErrCode::TypeError,
-                        })
+                        });
                     }
                 };
                 Ok(Value::Integer(out))
@@ -211,7 +251,7 @@ impl Value {
                         return Err(VmError {
                             msg: format!("Invalid float `{}`", payload),
                             errcode: ErrCode::TypeError,
-                        })
+                        });
                     }
                 };
                 Ok(Value::Float(out))
@@ -339,7 +379,7 @@ impl Value {
     pub fn dict_get(&self, key: &Value) -> Result<Option<Value>, VmError> {
         match self {
             Value::Dict(d) => {
-                for (k, v) in d.iter() {
+                for (k, v) in d.borrow().iter() {
                     if k == key {
                         return Ok(Some(v.clone()));
                     }
@@ -349,16 +389,32 @@ impl Value {
             _ => Err(VmError::make_type_error("dict", self)),
         }
     }
+    pub fn dict_set(&mut self, key: &Value, val: &Value) -> Result<(), VmError> {
+        match self {
+            Value::Dict(d) => {
+                let mut d = d.borrow_mut();
+                for (k, v) in d.iter_mut() {
+                    if k == key {
+                        *v = val.clone();
+                        return Ok(());
+                    }
+                }
+                d.push((key.clone(), val.clone()));
+                Ok(())
+            }
+            _ => Err(VmError::make_type_error("dict", self)),
+        }
+    }
     pub fn dict_display(&self, vm: &mut VM) -> Result<String, VmError> {
         match self {
             Value::Dict(d) => {
                 let mut out = String::new();
                 out.push_str("%{");
-                for (i, (k, v)) in d.iter().enumerate() {
+                for (i, (k, v)) in d.borrow().iter().enumerate() {
                     out.push_str(&k.repr(vm));
                     out.push_str(": ");
                     out.push_str(&v.repr(vm));
-                    if i != d.len() - 1 {
+                    if i != d.borrow().len() - 1 {
                         out.push_str(", ")
                     }
                 }
@@ -409,7 +465,7 @@ pub enum ErrCode {
     InvalidOperation = 16,
     IndexError = 17,
     MathError = 18,
-    OverflowError = 19
+    OverflowError = 19,
 }
 impl fmt::Display for ErrCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -758,14 +814,14 @@ fn vm_len(_vm: &mut VM, args: &[Value]) -> Result<Value, VmError> {
                 .dict_get(&Value::String(Rc::new("_len".to_string())))
                 .unwrap()
             {
-                None => Ok(Value::Integer(d.len().try_into().unwrap())),
+                None => Ok(Value::Integer(d.borrow().len().try_into().unwrap())),
                 Some(v) => match v {
                     Value::Func(v) => Ok(Value::CallRequest(
                         v.clone(),
                         Rc::new(vec![args[0].clone()]),
                     )), // TODO: perhaps find out how to not clone this
                     Value::Integer(v) => Ok(Value::Integer(v)),
-                    _ => Ok(Value::Integer(d.len().try_into().unwrap())),
+                    _ => Ok(Value::Integer(d.borrow().len().try_into().unwrap())),
                 },
             }
         }

--- a/kovm/src/vm.rs
+++ b/kovm/src/vm.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Env, ErrCode, Export, KoniFunc, Module, RuntimeType, Value, VmError, VmPanic,
+    self, Env, ErrCode, Export, KoniFunc, Module, RuntimeType, Value, VmError, VmPanic
 };
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -504,7 +504,7 @@ impl VM {
         if self.get_i() > self.ins.len() {
             panic!("Invalid i")
         }
-        let operators = &self.ins[self.get_i()];
+        let operators = &self.ins[self.get_i()].clone();
         let mut returned = false;
         match operators[0].as_str() {
             "JMP" => {
@@ -614,7 +614,7 @@ impl VM {
                     };
                     map.push((k, v));
                 }
-                self.push_to_stack(Value::Dict(Rc::new(map)));
+                self.push_to_stack(Value::Dict(Rc::new(map.into())));
             }
             "PUSH_CONST" => {
                 let item: Value = self.const_pool[operators[1].parse::<usize>().unwrap()].clone();
@@ -747,41 +747,7 @@ impl VM {
 
                 match item {
                     Value::Array(arr) => {
-                        let idx = match rhs {
-                            Value::Integer(v) => {
-                                if v < 0 {
-                                    let abs = match v.checked_abs() {
-                                        Some(v) => v as usize,
-                                        None => return Err(
-                                            VmError {
-                                                msg: "Integer overflow".into(),
-                                                errcode: ErrCode::OverflowError
-                                            }
-                                        )
-                                    };
-                                    let len = arr.borrow().len();
-                                    if abs > len {
-                                        return Err(VmError {
-                                            msg: format!("Index {} out of bounds", v),
-                                            errcode: ErrCode::IndexError,
-                                        });
-                                    }
-                                    len - abs
-                                } else {
-                                    v as usize
-                                }
-                            }
-                            _ => {
-                                return Err(VmError {
-                                    msg: format!(
-                                        "Cannot index into an array with type `{}`",
-                                        rhs.display()
-                                    ),
-                                    errcode: ErrCode::TypeError,
-                                });
-                            }
-                        };
-
+                        let idx = runtime::arr_idx_resolve(&rhs, &arr)?;
                         match arr.borrow().get::<usize>(idx as usize) {
                             Some(v) => self.push_to_stack(v.clone()),
                             None => {
@@ -913,6 +879,40 @@ impl VM {
                         }
                         .clone(),
                     ),
+                }
+            }
+            "SET_ATTR" => {
+                let val = self.pop_from_stack()?;
+                let mut item = self.pop_from_stack()?;
+                let attr = into_usize(get_op(operators, 1, "SET_ATTR")?.as_str())?;
+                let attr= match self.const_pool.get(attr) {
+                    None => todo!(), // TODO
+                    Some(v) => v
+                };
+                match item {
+                    Value::Dict(_) => {
+                        item.dict_set(attr, &val)?;
+                    },
+                    _ => return Err(
+                        VmError {
+                            msg: format!("Cannot set an attribute of type `{}`", item.display()),
+                            errcode: ErrCode::TypeError
+                        }
+                    )
+                }
+            },
+            "SET_INDEX" => {
+                let val = self.pop_from_stack()?;
+                let idx = self.pop_from_stack()?;
+                let item = self.pop_from_stack()?;
+
+                match item {
+                    Value::Array(arr) => {
+                        let idx = runtime::arr_idx_resolve(&idx, &arr)?;
+
+                        arr.borrow_mut()[idx] = val
+                    },
+                    _ => todo!()
                 }
             }
             "CALL" => {

--- a/kovm/src/vm.rs
+++ b/kovm/src/vm.rs
@@ -886,7 +886,12 @@ impl VM {
                 let mut item = self.pop_from_stack()?;
                 let attr = into_usize(get_op(operators, 1, "SET_ATTR")?.as_str())?;
                 let attr= match self.const_pool.get(attr) {
-                    None => todo!(), // TODO
+                    None => return Err(
+                        VmError {
+                            msg: format!("Expected a value at constant pool idx {} for SET_ATTR", attr),
+                            errcode: ErrCode::ValueError
+                        }
+                    ),
                     Some(v) => v
                 };
                 match item {
@@ -904,7 +909,7 @@ impl VM {
             "SET_INDEX" => {
                 let val = self.pop_from_stack()?;
                 let idx = self.pop_from_stack()?;
-                let item = self.pop_from_stack()?;
+                let mut item = self.pop_from_stack()?;
 
                 match item {
                     Value::Array(arr) => {
@@ -912,7 +917,10 @@ impl VM {
 
                         arr.borrow_mut()[idx] = val
                     },
-                    _ => todo!()
+                    Value::Dict(_) => {
+                        item.dict_set(&idx, &val)?;
+                    }
+                    _ => return Err(VmError::make_type_error("array` or `dict", &item))
                 }
             }
             "CALL" => {

--- a/specs/documentation/errors.md
+++ b/specs/documentation/errors.md
@@ -161,6 +161,14 @@ Used when you use an invalid escape sequence in a string:
 println('the escape sequence \g does not exist')
 ```
 
+### 18: Invalid assignment target
+
+Used when you try to assign a value to something that cannot be assigned to:
+
+```koniscript
+'foo' = 'bar'
+```
+
 ## Runtime (VM) errors
 
 This section is for errors raised by the runtime (`kovm`)

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -1328,6 +1328,17 @@ class Parser:
             name,
         )
 
+    def is_assignable(self, e: ASTNode):
+        match e:
+            case GetIndex():
+                return True
+            case Attribute():
+                return True
+            case Variable():
+                return True
+            case _:
+                return False
+
     def statement(self) -> Generator[ParserWarn, None, ASTNode | None]:
         self.skip_newline()
         if self.current_token.type == TokenType.RBRACE:
@@ -1407,63 +1418,22 @@ class Parser:
                 )
             value = yield from self.expr()
             return Return(ln, col, value.end_line, value.end_col, value)
-        elif self.current_token.type == TokenType.IDENTIFIER:
-            next_tok = self.peek()
-            if next_tok and next_tok.type == TokenType.ASSIGN:
-                ln = self.current_token.line
-                col = self.current_token.col
-                name = self.eat(TokenType.IDENTIFIER).value
-                self.eat(TokenType.ASSIGN)
-                value = yield from self.expr()
-                return Assign(ln, col, value.end_line, value.end_col, name, value)
-            elif next_tok and next_tok.type in (
-                TokenType.PLUS_ASSIGN,
-                TokenType.DIV_ASSIGN,
-                TokenType.MUL_ASSIGN,
-                TokenType.SUB_ASSIGN,
-            ):
-                ln = self.current_token.line
-                col = self.current_token.col
-                name = self.eat(TokenType.IDENTIFIER).value
-                op_token = self.current_token
-                op_type = op_token.type
-                self.eat(op_type)
-                op_map = {
-                    TokenType.PLUS_ASSIGN: BinOpType(TokenType.ADD),
-                    TokenType.SUB_ASSIGN: BinOpType(TokenType.SUB),
-                    TokenType.MUL_ASSIGN: BinOpType(TokenType.MUL),
-                    TokenType.DIV_ASSIGN: BinOpType(TokenType.DIV),
-                }
-                op = op_map.get(op_type)
-                if op is None:
-                    raise ParserError(
-                        5,
-                        'Internal error: unexpected assignment operator',
-                        op_token.line,
-                        op_token.col,
-                        op_token.end_line,
-                        op_token.end_col,
-                        self.fp,
-                        self.file_content,
-                    )
-                value = yield from self.expr()
-                return Assign(
-                    ln,
-                    col,
-                    value.end_line,
-                    value.end_col,
-                    name,
-                    BinOp(
-                        ln,
-                        col,
-                        value.end_line,
-                        value.end_col,
-                        Variable(ln, col, op_token.end_line, op_token.end_col, name),
-                        op,
-                        value,
-                    ),
-                )
         e = yield from self.expr()
+
+        if self.current_token.type in (TokenType.ASSIGN, TokenType.PLUS_ASSIGN, TokenType.MUL_ASSIGN, TokenType.SUB_ASSIGN):
+            t = self.current_token.type
+            self.eat(t)
+            value = yield from self.expr()
+            if not self.is_assignable(e):
+                raise RuntimeError('no implemented')
+            match e:
+                case Variable():
+                    return Assign(e.line, e.col, e.end_line, e.end_col, e.name, value)
+                case GetIndex():
+                    return SetIndex(e.line, e.col, e.end_line, e.end_col, e.idx, value, e.item)
+                case Attribute():
+                    return SetAttr(e.line, e.col, e.end_line, e.end_col, e.attr, e.val, value)
+            
         return e
 
     def if_decl(self) -> Generator[ParserWarn, None, If]:
@@ -1583,8 +1553,8 @@ class Parser:
             Function(ln, col, body.end_line, body.end_col, params, body),
         )
 
-    def peek(self):
-        idx = self.pos + 1
+    def peek(self, amnt=1):
+        idx = self.pos + amnt
         if idx < len(self.tokens):
             return self.tokens[idx]
         return Token(TokenType.EOF, None, 0, 0, 0, 0)
@@ -1717,8 +1687,8 @@ class Call(ASTNode):
 
 @dataclass
 class Attribute(ASTNode):
-    lhs: ASTNode
-    rhs: str
+    val: ASTNode
+    attr: str
 
 
 @dataclass
@@ -1738,6 +1708,16 @@ class BinOp(ASTNode):
 class Variable(ASTNode):
     name: str
 
+@dataclass 
+class SetIndex(ASTNode):
+    idx: ASTNode
+    value: ASTNode
+    item: ASTNode
+@dataclass
+class SetAttr(ASTNode):
+    attr: str
+    item: ASTNode
+    value: ASTNode
 
 @dataclass
 class FunctionParameter(ASTNode):
@@ -2346,24 +2326,24 @@ class Compiler:
                 atr_itm: (
                     tuple[str, int, int, tuple[tuple[str, str, str], ...] | None] | None
                 ) = None
-                if isinstance(node.func.lhs, Variable):
-                    obj = self.get_var_obj(node.func.lhs.name)
+                if isinstance(node.func.val, Variable):
+                    obj = self.get_var_obj(node.func.val.name)
                     if obj is not None and isinstance(obj[0].value, self.Module):
                         exports = obj[0].value.exports
                         for item in exports:
-                            if item.name == node.func.rhs:
+                            if item.name == node.func.attr:
                                 exported = item
                                 break
                 if exported is None:
                     for item in self.attrs:
-                        if item[0] == node.func.rhs:
+                        if item[0] == node.func.attr:
                             atr_itm = item
                             break
                     if atr_itm is None:
                         if 'types.dicts' not in self.reqs:  # TODO
                             raise CompilerError(
                                 12,
-                                f'No attribute `{node.func.rhs}` found',
+                                f'No attribute `{node.func.attr}` found',
                                 node.line,
                                 node.col,
                                 node.end_line,
@@ -2497,6 +2477,7 @@ class Compiler:
                     self.emit(node.line, OpcodeType.CALL, len(node.args))
                 else:
                     raise
+            
             elif isinstance(node.func, Attribute):
                 if exported is not None:
                     if isinstance(exported.item, Function):
@@ -2539,6 +2520,18 @@ class Compiler:
             for item in reversed(node.items):
                 yield from self.compile_ins(item)
             self.emit(node.line, 'BUILD_ARRAY', len(node.items))
+        elif isinstance(node, SetIndex):
+            yield from self.raise_for_req('indexes', 'Index', 'Indexing', node)
+            yield from self.compile_ins(node.item)
+            yield from self.compile_ins(node.idx)
+            yield from self.compile_ins(node.value)
+            self.emit(node.line, 'SET_INDEX')
+        elif isinstance(node, SetAttr):
+            yield from self.raise_for_req('attributes', 'Attribute', 'Attributes', node)
+            yield from self.compile_ins(node.item)
+            yield from self.compile_ins(node.value)
+            i = self.add_constant((T_STRING, node.attr))
+            self.emit(node.line, 'SET_ATTR', i)
         elif isinstance(node, KoniDict):
             yield from self.raise_for_req(
                 'types.dicts', 'Dictionary', 'Dictionaries', node
@@ -2621,31 +2614,31 @@ class Compiler:
                     self,
                 )
             else:
-                if isinstance(node.lhs, Variable):
-                    itm = self.get_var_obj(node.lhs.name)
+                if isinstance(node.val, Variable):
+                    itm = self.get_var_obj(node.val.name)
                     if itm is not None and isinstance(itm[0].value, self.Module):
                         exports = itm[0].value.exports
                         for item in exports:
-                            if item.name == node.rhs:
+                            if item.name == node.attr:
                                 broken = True
                                 break
                 if not broken:
                     for item in self.attrs:
-                        if item[0] == node.rhs:
+                        if item[0] == node.attr:
                             broken = True
                             break
                     if not broken:
                         raise CompilerError(
                             12,
-                            f'Could not find attribute {node.rhs}',
+                            f'Could not find attribute {node.attr}',
                             node.line,
                             node.col,
                             node.end_line,
                             node.end_col,
                             self.mod_stack[-1].fp,
                         )
-            yield from self.compile_ins(node.lhs)
-            idx = self.add_constant((T_STRING, node.rhs))
+            yield from self.compile_ins(node.val)
+            idx = self.add_constant((T_STRING, node.attr))
             self.emit(node.line, 'GETATTR', idx)
         elif isinstance(node, GetIndex):
             yield from self.raise_for_req('indexes', 'Index', 'Indexing', node)

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -1428,11 +1428,11 @@ class Parser:
                 raise RuntimeError('no implemented')
             match e:
                 case Variable():
-                    return Assign(e.line, e.col, e.end_line, e.end_col, e.name, value)
+                    return Assign(e.line, e.col, value.end_line, value.end_col, e.name, value)
                 case GetIndex():
-                    return SetIndex(e.line, e.col, e.end_line, e.end_col, e.idx, value, e.item)
+                    return SetIndex(e.line, e.col, value.end_line, value.end_col, e.idx, value, e.item)
                 case Attribute():
-                    return SetAttr(e.line, e.col, e.end_line, e.end_col, e.attr, e.val, value)
+                    return SetAttr(e.line, e.col, value.end_line, value.end_col, e.attr, e.val, value)
             
         return e
 

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -1425,7 +1425,16 @@ class Parser:
             self.eat(t)
             value = yield from self.expr()
             if not self.is_assignable(e):
-                raise RuntimeError('no implemented')
+                raise ParserError(
+                    18,
+                    'Invalid assignment target',
+                    e.line,
+                    e.col,
+                    value.end_line,
+                    value.end_col,
+                    self.fp,
+                    self.file_content
+                )
             match e:
                 case Variable():
                     return Assign(e.line, e.col, value.end_line, value.end_col, e.name, value)


### PR DESCRIPTION
Resolves #85.

## Summary by Sourcery

Add support for assigning to variables, indexed items and attributes in the language and VM, including validation of assignment targets and corresponding bytecode operations.

New Features:
- Support assignment expressions targeting variables, index operations and attribute accesses in the parser and code generator.
- Introduce SET_INDEX and SET_ATTR bytecode operations and VM handlers to mutate arrays and dictionaries at runtime.
- Add a new compiler error 18 for invalid assignment targets with user-facing documentation.

Enhancements:
- Refactor attribute AST nodes and compiler usage to distinguish attribute names and receiver values more clearly.
- Make dictionary values internally mutable via RefCell and add helper methods for setting entries and computing length.
- Extract shared array index resolution logic into a reusable runtime helper function used by both GET_INDEX and SET_INDEX.