### PR TITLE
Fix division

### DIFF
--- a/kovm/src/runtime.rs
+++ b/kovm/src/runtime.rs
@@ -881,7 +881,7 @@ fn div(a: Value, b: Value, _vm: &mut VM) -> Result<Value, VmError> {
                     errcode: ErrCode::MathError,
                 })
             } else {
-                Ok(Value::Integer(va / vb))
+                Ok(Value::Float(*va as f64 / *vb as f64))
             }
         }
         (Value::Float(va), Value::Integer(vb)) => {
@@ -1726,8 +1726,8 @@ mod tests {
 
         let res = div(Value::Integer(6), Value::Integer(3), &mut vm).unwrap();
         match res {
-            Value::Integer(i) => assert_eq!(i, 2),
-            _ => panic!("Expected integer"),
+            Value::Float(i) => assert_eq!(i, 2.0),
+            _ => panic!("Expected float"),
         }
 
         let res = div(Value::Float(7.0), Value::Float(2.0), &mut vm).unwrap();

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -86,7 +86,7 @@ def test_unary_negation():
 
 def test_floats():
     out = koni.run(TESTS / 'test_floats.kn').stdout
-    assert out == b'3.14\n4\n2\n'
+    assert out == b'3.14\n4\n2.5\n'
 
 
 def test_null():


### PR DESCRIPTION
Makes `int/int` give a float

## Summary by Sourcery

Make integer division return a floating-point result instead of truncating to an integer.

Bug Fixes:
- Correct integer-division runtime behavior to produce a float result for int/int operands.

Tests:
- Update runtime and Python tests to assert floating-point results for integer division and float-related output.