### PR TITLE
fix(runtime): Add support for NEG on floats

### DIFF
--- a/kovm/src/vm.rs
+++ b/kovm/src/vm.rs
@@ -994,6 +994,7 @@ impl VM {
                 };
                 let out = match v {
                     Value::Integer(val) => Value::Integer(0 - val),
+                    Value::Float(val) => Value::Float(0.0 - val),
                     _ => {
                         return Err(VmError {
                             msg: format!("Cannot convert a {} to a negative value", v.display()),


### PR DESCRIPTION
Adds support for `-5.2`

## Summary by Sourcery

Bug Fixes:
- Allow NEG operations on float values without causing a runtime error.