### PR TITLE
Add `let`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Functions are also first class
 ```koniscript
 func run_with_message(f) {
   println('Running...')
-val = f() # Note that this will raise a warning, as the compiler can't check the number of arguments. This will be fixed when the type checker is released.
+  val = f() # Note that this will raise a warning, as the compiler can't check the number of arguments. This will be fixed when the type checker is released.
   println('Completed!')
   return val
 }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ println('foo, bar', 'baz') # The println function takes multiple arguments, and 
 - Variables:
 
 ```koniscript
-this_is_a_var = 'foo'
+let this_is_a_var = 'foo'
 println(this_is_a_var)
 ```
 
@@ -61,7 +61,7 @@ println(5 + 5 / 2)
 - Conditionals:
 
 ```koniscript
-num = input('Enter a number\n>>> ') # The input function prints a message and waits for user input, returning the input given by the user.
+let num = input('Enter a number\n>>> ') # The input function prints a message and waits for user input, returning the input given by the user.
 
 println(num == 5)
 if num == 5 {
@@ -76,10 +76,10 @@ if num == 5 {
 - While loops
 
 ```koniscript
-i = 0
+let i = 0
 while i < 5 {
   println(i)
-  i+=1
+  i+=1 # There is no `let` here, so it uses the variable `i` declared above
 }
 ```
 
@@ -103,7 +103,7 @@ Functions are also first class
 ```koniscript
 func run_with_message(f) {
   println('Running...')
-  val = f() # Note that this will raise a warning, as the compiler can't check the number of arguments. This will be fixed when the type checker is released.
+  let val = f() # Note that this will raise a warning, as the compiler can't check the number of arguments. This will be fixed when the type checker is released.
   println('Completed!')
   return val
 }
@@ -122,7 +122,7 @@ run_with_message(some_callback)
 println('hi'.upper())
 
 @require types.arrays {
-  arr = []
+  let arr = []
   arr.push('test')
 } else {
   println('Arrays not supported') # Any code that tries to use arrays in here will fail to compile
@@ -139,7 +139,7 @@ Note that using a feature that is under a requirement will implicitly add the re
 ```koniscript
 @require types.arrays
 
-a = [
+let a = [
   'foo',
   'bar'
 ]
@@ -156,7 +156,7 @@ println(a) # => ['foo', 'bar', 'baz']
 ```koniscript
 @require types.dicts
 
-a = %{
+let a = %{
   'foo': 'bar',
   'baz': 5,
   5: 'boo'

--- a/koni_lsp/editors/vscode/syntaxes/koniscript.tmLanguage.json
+++ b/koni_lsp/editors/vscode/syntaxes/koniscript.tmLanguage.json
@@ -32,7 +32,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.koniscript",
-					"match": "(?<!\\.)(\\b(if|while|func|return|else|or|and|not|import|break)\\b|@require)"
+					"match": "(?<!\\.)(\\b(if|while|func|return|else|or|and|not|import|break|let|continue|null|export)\\b|@require)"
 				},
 				{
 					"name": "constant.character.koniscript",

--- a/kovm/src/main.rs
+++ b/kovm/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use owo_colors::OwoColorize;
-use std::process::exit;
 use std::fs;
+use std::process::exit;
 mod runtime;
 mod vm;
 use vm::VM;
@@ -37,9 +37,6 @@ fn val(file: String) {
     };
 }
 
-
-
-
 fn run(file: String) {
     let contents = fs::read_to_string(file).expect("Could not read file");
     let contents: Vec<String> = contents.lines().map(|s| s.to_string()).collect();
@@ -65,7 +62,7 @@ fn run(file: String) {
             let lines_opt = vm.lines.as_ref();
             let source_opt = vm.sources;
 
-            for (frame_idx, frame) in vm.frames.iter().rev().enumerate() {
+            for (frame_idx, frame) in vm.frames.iter().enumerate() {
                 if frame_idx > 0 {
                     println!()
                 } // Add space between frames
@@ -119,6 +116,7 @@ fn run(file: String) {
                     println!("  at {} ({})", frame.name.cyan(), ip_str);
                 }
             }
+            println!("\n{}: {}", e.errcode.to_string().red().bold(), e.msg.red());
         }
     }
 }

--- a/specs/documentation/errors.md
+++ b/specs/documentation/errors.md
@@ -41,20 +41,20 @@ if {
 Used when an identifier isn't used after a `.` (attribute)
 
 ```koniscript
-a = 'hi'
+let a = 'hi'
 a.
 ```
 
 or
 
 ```koniscript
-a = 'hi'
+let a = 'hi'
 a.2
 ```
 
 ### 5: Cannot export anything other than an assignment or function
 
-Used when you attempt to export anything other than an assignment or function:
+Used when you attempt to export anything other than a declaration or function:
 
 ```koniscript
 export "foo"
@@ -87,7 +87,7 @@ Used when the compiler is told to include source info, but doesn't receive it (i
 Used when you use a variable (or function) before declaring it
 
 ```koniscript
-print(a) # But a was never declared (a='foo' was never ran)
+print(a) # But a was never declared (`let a='foo'` was never ran)
 ```
 
 ### 11: Invalid arg count (10 was removed)
@@ -105,7 +105,7 @@ foo('bar') # <- Expected exactly 0 arguments, got 1
 or
 
 ```koniscript
-func foo(bar='baz') {
+func foo(bar='baz') { # Note that default arguments are very unstable, see [#34](https://github.com/DELOLCAT/koniscript/issues/34)
 
 }
 
@@ -197,7 +197,7 @@ Used when you supply an invalid number of arguments to a function:
 func foo(bar) {
     # ...
 }
-a = foo
+let a = foo
 a() # <- 0 arguments, and the compiler cannot catch this as of now
 ```
 
@@ -242,21 +242,10 @@ As you can see above, there is no target to jump to
 
 ### 6: Variable Not Found
 
-Used when the runtime reaches a variable that hasn't been declared in the current scope. Note that the compiler would prevent this from happening, except in this edge case, as closures aren't fully implemented yet:
+Used when the runtime reaches a variable that hasn't been declared in the current scope. Note that the compiler would prevent this from happening.
 
 ```koniscript
-func make_counter() {
-    x = 0 # <- Could not find a variable at slot `x:x`, where both `x`es are integers
-    func count() {
-        x += 1
-        return x
-    }
-    return count
-}
-
-a = make_counter()
-println(a())
-println(a())
+println(foo) # The compiler somehow didn't catch that `foo` has never been declared
 ```
 
 ### 7: StackUnderflow
@@ -305,7 +294,7 @@ Used when the VM attempts to run code that requires a feature which it doesn't s
 For instance, let's say that we have a program with this:
 
 ```koniscript
-@require arrays
+@require types.arrays
 
 a = [
     'foo',
@@ -353,7 +342,7 @@ Used when an attribute cannot be found for an item:
 
 ### 15: ExitSignal
 
-Internal. Used when a builtin wants to exit the VM. This may not exist in other implementations
+Internal. Used when a builtin wants to make the VM exit. This may not exist in other implementations
 
 ### 16: InvalidOperation
 

--- a/specs/documentation/errors.md
+++ b/specs/documentation/errors.md
@@ -60,6 +60,12 @@ Used when you attempt to export anything other than a declaration or function:
 export "foo"
 ```
 
+or when you try to export an empty declaration:
+
+```koniscript
+export let foo
+```
+
 ### 6: Module not found
 
 Used when the compiler can't find an imported module
@@ -88,6 +94,12 @@ Used when you use a variable (or function) before declaring it
 
 ```koniscript
 print(a) # But a was never declared (`let a='foo'` was never ran)
+```
+
+or
+
+```koniscript
+foo = 'bar' # But you never declared foo with `let foo`
 ```
 
 ### 11: Invalid arg count (10 was removed)

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -366,9 +366,6 @@ class Tokenizer:
             )
 
     def parse_escape_seq(self, char: Literal['"', "'", '`']):
-        if self.get_current_char() == '\\':
-            self.advance()
-
         def hex_tokenize(amnt: int):
             def hex_check(c: str):
                 return c[0].lower() not in '0123456789abcdef'
@@ -2596,64 +2593,7 @@ class Compiler:
                         'runtime_values', 'Runtime Value', 'Runtime Values', node
                     )
                 self.emit(node.line, 'PUSH_BUILTIN', idx[0])
-        elif isinstance(node, Declare) and isinstance(node.value, Function):
-            # res = self.get_var(node.name)
-            # if res is None:
-            #     idx = self.declare_local(node.name, node.value)
-            #     yield from self.compile_ins(node.value, node.name)
-            #     if len(other) > 0 and other[0]:
-            #         self.emit(node.line, 'DUP')
-            #     self.emit(node.line, OP_SET_VAR, idx, 0)
-            #     return idx, 0
-            # else:
-            #     idx, cat, depth = res
-            #     yield from self.compile_ins(node.value, node.name)
-# 
-            #     idx = self.declare_local(node.name, node.value)
-            #     if len(other) > 0 and other[0]:
-            #         self.emit(node.line, 'DUP')
-            #     if depth is None:
-            #         depth = 0
-            #     self.emit(node.line, OP_SET_VAR, idx, depth)
-# 
-            #     yield CompilerWarn(
-            #         f'Reassignment to a function attempted for {node.name}(). This is usually not recommended',
-            #         node.line,
-            #         node.col,
-            #         node.end_line,
-            #         node.end_col,
-            #         self.mod_stack[-1].fp,
-            #         self,
-            #     )
-            #     return idx, 0
-            yield from self.compile_declare(node)
         elif isinstance(node, Assign):
-            # res = self.get_var(node.name)
-            # if res is None:
-            #     # yield from self.compile_ins(node.value)
-            #     # idx = self.declare_local(node.name, node.value)
-            #     # if len(other) > 0 and other[0]:
-            #     #     self.emit(node.line, 'DUP')
-            #     # self.emit(node.line, OP_SET_VAR, idx, 0)
-            #     # depth = 0
-            #     raise CompilerError(
-            #         -4, # TODO
-            #         f'Undeclared variable {node.name}',
-            #         node.line,
-            #         node.col,
-            #         node.end_line,
-            #         node.end_col,
-            #         self.mod_stack[-1].fp
-            #     )
-            # else:
-            #     idx, _, depth = res
-            #     yield from self.compile_ins(node.value)
-            #     idx = self.declare_local(node.name, node.value)
-            #     if len(other) > 0 and other[0]:
-            #         self.emit(node.line, 'DUP')
-            #     if depth is None:
-            #         depth = 0
-            #     self.emit(node.line, OP_SET_VAR, idx, depth)
             yield from self.compile_ins(node.value)
             s = self.set_local(node.name, node.value)
             if s is None:

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -2528,9 +2528,11 @@ class Compiler:
             if node.value is not None
             else Null(node.line, node.col, node.end_line, node.end_col)
         )
-        
+        if not isinstance(node.value, Function):
+            yield from self.compile_ins(v)
         idx = self.declare_local(node.name, v)
-        yield from self.compile_ins(v)
+        if isinstance(node.value, Function):
+            yield from self.compile_ins(v)
         if dup:
             self.emit(node.line, 'DUP')
         self.emit(node.line, OP_SET_VAR, idx, 0)

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Any, Collection, Generator, Literal, assert_never, cast
+from typing import Any, Collection, Generator, Literal, assert_never
 from koni_compiler import base_env
 from koni_compiler.runtime import (
     T_BOOL,
@@ -1333,7 +1333,7 @@ class Parser:
             )
         if out.value is None:
             raise ParserError(
-                -4,  # TODO
+                5,
                 'Exported declarations must have a value',
                 out.line,
                 out.col,
@@ -2598,7 +2598,7 @@ class Compiler:
             s = self.set_local(node.name, node.value)
             if s is None:
                 raise CompilerError(
-                    -4,  # TODO
+                    9,
                     f'Undeclared variable {node.name}',
                     node.line,
                     node.col,

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -2344,7 +2344,6 @@ class Compiler:
         for scope in reversed(self.scopes):
             if name in scope.var_map:
                 scope.var_map[name].value = value
-                print(depth, name, value)
                 return (depth, scope.var_map[name].idx)
             depth += 1
 
@@ -2532,10 +2531,11 @@ class Compiler:
             if node.value is not None
             else Null(node.line, node.col, node.end_line, node.end_col)
         )
+        
+        idx = self.declare_local(node.name, v)
         yield from self.compile_ins(v)
         if dup:
             self.emit(node.line, 'DUP')
-        idx = self.declare_local(node.name, v)
         self.emit(node.line, OP_SET_VAR, idx, 0)
 
     def compile_ins(
@@ -2597,35 +2597,36 @@ class Compiler:
                     )
                 self.emit(node.line, 'PUSH_BUILTIN', idx[0])
         elif isinstance(node, Declare) and isinstance(node.value, Function):
-            res = self.get_var(node.name)
-            if res is None:
-                idx = self.declare_local(node.name, node.value)
-                yield from self.compile_ins(node.value, node.name)
-                if len(other) > 0 and other[0]:
-                    self.emit(node.line, 'DUP')
-                self.emit(node.line, OP_SET_VAR, idx, 0)
-                return idx, 0
-            else:
-                idx, cat, depth = res
-                yield from self.compile_ins(node.value, node.name)
-
-                idx = self.declare_local(node.name, node.value)
-                if len(other) > 0 and other[0]:
-                    self.emit(node.line, 'DUP')
-                if depth is None:
-                    depth = 0
-                self.emit(node.line, OP_SET_VAR, idx, depth)
-
-                yield CompilerWarn(
-                    f'Reassignment to a function attempted for {node.name}(). This is usually not recommended',
-                    node.line,
-                    node.col,
-                    node.end_line,
-                    node.end_col,
-                    self.mod_stack[-1].fp,
-                    self,
-                )
-                return idx, 0
+            # res = self.get_var(node.name)
+            # if res is None:
+            #     idx = self.declare_local(node.name, node.value)
+            #     yield from self.compile_ins(node.value, node.name)
+            #     if len(other) > 0 and other[0]:
+            #         self.emit(node.line, 'DUP')
+            #     self.emit(node.line, OP_SET_VAR, idx, 0)
+            #     return idx, 0
+            # else:
+            #     idx, cat, depth = res
+            #     yield from self.compile_ins(node.value, node.name)
+# 
+            #     idx = self.declare_local(node.name, node.value)
+            #     if len(other) > 0 and other[0]:
+            #         self.emit(node.line, 'DUP')
+            #     if depth is None:
+            #         depth = 0
+            #     self.emit(node.line, OP_SET_VAR, idx, depth)
+# 
+            #     yield CompilerWarn(
+            #         f'Reassignment to a function attempted for {node.name}(). This is usually not recommended',
+            #         node.line,
+            #         node.col,
+            #         node.end_line,
+            #         node.end_col,
+            #         self.mod_stack[-1].fp,
+            #         self,
+            #     )
+            #     return idx, 0
+            yield from self.compile_declare(node)
         elif isinstance(node, Assign):
             # res = self.get_var(node.name)
             # if res is None:

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Any, Collection, Generator, Literal, assert_never
+from typing import Any, Collection, Generator, Literal, assert_never, cast
 from koni_compiler import base_env
 from koni_compiler.runtime import (
     T_BOOL,
@@ -78,6 +78,7 @@ class TokenType(Enum):
     FStringExprEnd = 'FStringExprEnd'
     FStringEnd = 'FStringEnd'
     CONTINUE = 'CONTINUE'
+    LET = 'LET'
 
 
 PRECEDENCE = {
@@ -132,6 +133,7 @@ KEYWORDS = {
     'null': TokenType.NULL,
     'break': TokenType.BREAK,
     'continue': TokenType.CONTINUE,
+    'let': TokenType.LET,
 }
 
 
@@ -1321,10 +1323,21 @@ class Parser:
                 self.fp,
                 self.file_content,
             )
-        if not isinstance(out, Assign):
+        if not isinstance(out, Declare):
             raise ParserError(
                 5,
-                'Cannot export anything other than an assignment or function',
+                'Cannot export anything other than an declaration or function',
+                out.line,
+                out.col,
+                self.current_token.end_line,
+                self.current_token.end_col,
+                self.fp,
+                self.file_content,
+            )
+        if out.value is None:
+            raise ParserError(
+                -4,  # TODO
+                'Exported declarations must have a value',
                 out.line,
                 out.col,
                 self.current_token.end_line,
@@ -1439,6 +1452,21 @@ class Parser:
                 )
             value = yield from self.expr()
             return Return(ln, col, value.end_line, value.end_col, value)
+        elif self.current_token.type == TokenType.LET:
+            let = self.eat(TokenType.LET)
+            name = self.eat(TokenType.IDENTIFIER)
+
+            if self.current_token.type == TokenType.ASSIGN:
+                self.eat(TokenType.ASSIGN)
+                val = yield from self.expr()
+                end_line = val.end_line
+                end_col = val.end_col
+            else:
+                val = None
+                end_line = name.end_line
+                end_col = name.end_col
+            return Declare(let.line, let.col, end_line, end_col, name.value, val)
+
         e = yield from self.expr()
 
         if self.current_token.type in (
@@ -1614,13 +1642,13 @@ class Parser:
         self.eat(TokenType.RPAREN)
 
         body = yield from self.block()
-        return Assign(
+        return Declare(
             ln,
             col,
             body.end_line,
             body.end_col,
             name,
-            Function(ln, col, body.end_line, body.end_col, params, body),
+            Function(ln, col, body.end_line, body.end_col, params, body, name),
         )
 
     def peek(self, amnt=1):
@@ -1811,6 +1839,12 @@ class Assign(ASTNode):
 
 
 @dataclass
+class Declare(ASTNode):
+    name: str
+    value: ASTNode | None
+
+
+@dataclass
 class String(ASTNode):
     value: str
 
@@ -1829,6 +1863,7 @@ class Return(ASTNode):
 class Function(ASTNode):
     params: list[FunctionParameter]
     body: Block
+    name: str
 
 
 @dataclass
@@ -2124,6 +2159,7 @@ def fold_node(node: ASTNode, fp: str) -> ASTNode:
             ):
                 return Bool(s.line, s.col, s.end_line, s.end_col, a.value >= b.value)
         return s
+
     def neg(s: UnaryOp) -> ASTNode:
         match s.right:
             case Number():
@@ -2131,12 +2167,13 @@ def fold_node(node: ASTNode, fp: str) -> ASTNode:
             case Float():
                 return Float(s.line, s.col, s.end_line, s.end_col, 0 - s.right.value)
         return s
-    
+
     def not_(s: UnaryOp) -> ASTNode:
         match s.right:
             case Bool():
-                return Bool(s.line, s.col, s.end_line, s.end_col, not s.right)
+                return Bool(s.line, s.col, s.end_line, s.end_col, not s.right.value)
         return s
+
     match node:
         case BinOp():
             node.left = fold_node(node.left, fp)
@@ -2174,7 +2211,7 @@ def fold_node(node: ASTNode, fp: str) -> ASTNode:
                     assert_never(node.op)
         case UnaryOp():
             node.right = fold_node(node.right, fp)
-            
+
             match node.op:
                 case UnaryOpType.NEG:
                     return neg(node)
@@ -2274,6 +2311,7 @@ class Compiler:
     @dataclass
     class Result:
         value: str
+
     def make_warn(self, node: ASTNode, msg: str):
         yield CompilerWarn(
             msg,
@@ -2282,8 +2320,9 @@ class Compiler:
             node.end_line,
             node.end_col,
             self.mod_stack[-1].fp,
-            self
+            self,
         )
+
     def enter_scope(self, var_map=None, args=None):
         self.scopes.append(Compiler.Scope(var_map, args))
 
@@ -2299,11 +2338,20 @@ class Compiler:
         self.const_map[value_tuple] = index
         return index
 
+    def set_local(self, name: str, value: ASTNode) -> tuple[int, int] | None:
+        depth = 0
+        scope = self.scopes[-1]
+        for scope in reversed(self.scopes):
+            if name in scope.var_map:
+                scope.var_map[name].value = value
+                print(depth, name, value)
+                return (depth, scope.var_map[name].idx)
+            depth += 1
+
     def declare_local(self, name: str, value: ASTNode):
         scope = self.scopes[-1]
-        if name in scope.var_map:
-            return scope.var_map[name].idx
-
+        # if name in scope.var_map:
+        #    return scope.var_map[name].idx
         index = scope.next_local
         scope.var_map[name] = Compiler.ScopeItem(index, value)
         scope.next_local += 1
@@ -2478,6 +2526,18 @@ class Compiler:
                         self,
                     )
 
+    def compile_declare(self, node: Declare, dup: bool = False):
+        v = (
+            node.value
+            if node.value is not None
+            else Null(node.line, node.col, node.end_line, node.end_col)
+        )
+        yield from self.compile_ins(v)
+        if dup:
+            self.emit(node.line, 'DUP')
+        idx = self.declare_local(node.name, v)
+        self.emit(node.line, OP_SET_VAR, idx, 0)
+
     def compile_ins(
         self, node: ASTNode, *other
     ) -> Generator[CompilerWarn | ModuleRequest, ModuleReceived | None, Any]:
@@ -2536,7 +2596,7 @@ class Compiler:
                         'runtime_values', 'Runtime Value', 'Runtime Values', node
                     )
                 self.emit(node.line, 'PUSH_BUILTIN', idx[0])
-        elif isinstance(node, Assign) and isinstance(node.value, Function):
+        elif isinstance(node, Declare) and isinstance(node.value, Function):
             res = self.get_var(node.name)
             if res is None:
                 idx = self.declare_local(node.name, node.value)
@@ -2567,23 +2627,57 @@ class Compiler:
                 )
                 return idx, 0
         elif isinstance(node, Assign):
-            res = self.get_var(node.name)
-            if res is None:
-                yield from self.compile_ins(node.value)
-                idx = self.declare_local(node.name, node.value)
-                if len(other) > 0 and other[0]:
-                    self.emit(node.line, 'DUP')
-                self.emit(node.line, OP_SET_VAR, idx, 0)
-                depth = 0
-            else:
-                idx, _, depth = res
-                yield from self.compile_ins(node.value)
-                idx = self.declare_local(node.name, node.value)
-                if len(other) > 0 and other[0]:
-                    self.emit(node.line, 'DUP')
-                if depth is None:
-                    depth = 0
-                self.emit(node.line, OP_SET_VAR, idx, depth)
+            # res = self.get_var(node.name)
+            # if res is None:
+            #     # yield from self.compile_ins(node.value)
+            #     # idx = self.declare_local(node.name, node.value)
+            #     # if len(other) > 0 and other[0]:
+            #     #     self.emit(node.line, 'DUP')
+            #     # self.emit(node.line, OP_SET_VAR, idx, 0)
+            #     # depth = 0
+            #     raise CompilerError(
+            #         -4, # TODO
+            #         f'Undeclared variable {node.name}',
+            #         node.line,
+            #         node.col,
+            #         node.end_line,
+            #         node.end_col,
+            #         self.mod_stack[-1].fp
+            #     )
+            # else:
+            #     idx, _, depth = res
+            #     yield from self.compile_ins(node.value)
+            #     idx = self.declare_local(node.name, node.value)
+            #     if len(other) > 0 and other[0]:
+            #         self.emit(node.line, 'DUP')
+            #     if depth is None:
+            #         depth = 0
+            #     self.emit(node.line, OP_SET_VAR, idx, depth)
+            yield from self.compile_ins(node.value)
+            s = self.set_local(node.name, node.value)
+            if s is None:
+                raise CompilerError(
+                    -4,  # TODO
+                    f'Undeclared variable {node.name}',
+                    node.line,
+                    node.col,
+                    node.end_line,
+                    node.end_col,
+                    self.mod_stack[-1].fp,
+                )
+            self.emit(node.line, OP_SET_VAR, s[1], s[0])
+
+        elif isinstance(node, Declare):
+            # v = (
+            #     node.value
+            #     if node.value is not None
+            #     else Null(node.line, node.col, node.end_line, node.end_col)
+            # )
+            # yield from self.compile_ins(v)
+            # idx = self.declare_local(node.name, v)
+            # self.emit(node.line, OP_SET_VAR, idx, 0)
+            yield from self.compile_declare(node)
+
         elif isinstance(node, BinOp):
             yield from self.compile_ins(node.left)
             yield from self.compile_ins(node.right)
@@ -2887,12 +2981,12 @@ class Compiler:
             if node.else_body and compelse:
                 if jmps:
                     jmp2 = self.emit(node.line, 'JMP', None)
-                    self.code[jmp] = ('JMPIFF', len(self.code)) # pyright: ignore[reportPossiblyUnboundVariable]
+                    self.code[jmp] = ('JMPIFF', len(self.code))  # pyright: ignore[reportPossiblyUnboundVariable]
                 yield from self.compile_ins(node.else_body)
                 if jmps:
-                    self.code[jmp2] = ('JMP', len(self.code)) # pyright: ignore[reportPossiblyUnboundVariable]
+                    self.code[jmp2] = ('JMP', len(self.code))  # pyright: ignore[reportPossiblyUnboundVariable]
             elif jmps:
-                self.code[jmp] = ('JMPIFF', len(self.code)) # pyright: ignore[reportPossiblyUnboundVariable]
+                self.code[jmp] = ('JMPIFF', len(self.code))  # pyright: ignore[reportPossiblyUnboundVariable]
         elif isinstance(node, Array):
             yield from self.raise_for_req('types.arrays', 'Array', 'Arrays', node)
             for item in reversed(node.items):
@@ -2936,25 +3030,14 @@ class Compiler:
             local_count = self.scopes[-1].next_local
             self.exit_scope()
             self.code[jmp] = ('JMP', len(self.code))
-            if len(other) >= 1:
-                idx = self.add_constant([T_STRING, other[0]])
-                self.emit(
+            idx = self.add_constant([T_STRING, node.name])
+            self.emit(
                     node.line,
                     'MAKE_FUNCTION',
                     fn_entry,
                     local_count,
                     len(node.params),
                     idx,
-                )
-            else:
-                raise CompilerError(
-                    13,
-                    '(internal) Expected array `other` to have at least 1 value, found 0. This error should not be raised under any circumstance, please report at https://github.com/DELOLCAT/koniscript.',
-                    node.line,
-                    node.col,
-                    node.end_line,
-                    node.end_col,
-                    self.mod_stack[-1].fp,
                 )
         elif isinstance(node, Return):
             if node.value is None:
@@ -2964,8 +3047,8 @@ class Compiler:
             yield from self.compile_ins(node.value)
             self.emit(node.line, 'RET')
         elif isinstance(node, Export):
-            yield from self.compile_ins(
-                Assign(
+            yield from self.compile_declare(
+                Declare(
                     node.line,
                     node.col,
                     node.end_line,
@@ -2973,7 +3056,7 @@ class Compiler:
                     node.name,
                     node.lhs,
                 ),
-                True,
+                True
             )
             idx = self.add_constant((T_STRING, node.name))
             self.mod_stack[-1].exports.append(self.ExportItem(node.name, node.lhs))
@@ -3045,8 +3128,8 @@ class Compiler:
             self.emit(node.line, 'MAKE_MODULE', idx)
             md = self.mod_stack.pop()
             self.scopes[0].next_local += 1  # TODO: make this better
-            yield from self.compile_ins(
-                Assign(node.line, node.col, node.end_line, node.end_col, node.mod, md)
+            yield from self.compile_declare(
+                Declare(node.line, node.col, node.end_line, node.end_col, node.mod, md)
             )
         elif isinstance(node, self.Module):
             pass

--- a/tests/packages/test_mod.kn
+++ b/tests/packages/test_mod.kn
@@ -2,4 +2,4 @@ export func greet(name) {
     return 'Hello ' + name
 }
 
-export value = 42
+export let value = 42

--- a/tests/test_arr_dict_assign.kn
+++ b/tests/test_arr_dict_assign.kn
@@ -1,0 +1,24 @@
+let da = %{
+    'foo': 'bar',
+    'baz': 'boo'
+}
+
+da.foo = 'baz'
+println(da['foo'])
+
+da.baz = 'bar'
+println(da.baz)
+
+let aa = [
+    'foo',
+    'bar',
+    'baz'
+]
+
+aa[1] = 'boo'
+println('--')
+let i = 0
+while i < len(aa) {
+    println(aa[i])
+    i += 1
+}

--- a/tests/test_arrays.kn
+++ b/tests/test_arrays.kn
@@ -1,13 +1,13 @@
 @require types.arrays
 
-a = [1, 2, 3]
+let a = [1, 2, 3]
 println(a[0])
 println(a[1])
 
-b = ['hello', 'world']
+let b = ['hello', 'world']
 println(b[0])
 
-arr = []
+let arr = []
 arr.push('first')
 arr.push('second')
 println(arr[0])

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,5 @@
+import pytest
+
 from koni_compiler import koni
 from pathlib import Path
 
@@ -110,3 +112,8 @@ def test_closures():
 def test_arr_dict_assign():
     out = koni.run(TESTS / 'test_arr_dict_assign.kn').stdout
     assert out == b'baz\nbar\n--\nfoo\nboo\nbaz\n'
+    
+def test_decl_error():
+    with pytest.raises(SystemExit):
+        out = koni.run(TESTS / 'test_decl_error.kn')
+        assert out.returncode != 0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -102,3 +102,11 @@ def test_first_class_functions():
 def test_import():
     out = koni.run(TESTS / 'test_import.kn').stdout
     assert out == b'Hello World\n42\n'
+
+def test_closures():
+    out = koni.run(TESTS / 'test_closures.kn').stdout
+    assert out == b'2\n4\n4\n8\n12\n'
+    
+def test_arr_dict_assign():
+    out = koni.run(TESTS / 'test_arr_dict_assign.kn').stdout
+    assert out == b'baz\nbar\n--\nfoo\nboo\nbaz\n'

--- a/tests/test_break.kn
+++ b/tests/test_break.kn
@@ -1,4 +1,4 @@
-i = 0
+let i = 0
 while i < 10 {
     if i == 3 {
         break

--- a/tests/test_closures.kn
+++ b/tests/test_closures.kn
@@ -1,0 +1,19 @@
+func make_counter(incr) {
+    let i = 0
+    func count() {
+        i += incr
+        return i
+    }
+    return count
+}
+
+let counter = make_counter(2)
+
+println(counter())
+println(counter())
+
+let counter2 = make_counter(4)
+
+println(counter2())
+println(counter2())
+println(counter2())

--- a/tests/test_compound_assign.kn
+++ b/tests/test_compound_assign.kn
@@ -1,15 +1,15 @@
-x = 5
+let x = 5
 x += 3
 println(x)
 
-y = 10
+let y = 10
 y -= 4
 println(y)
 
-z = 2
+let z = 2
 z *= 3
 println(z)
 
-w = 12
+let w = 12
 w /= 4
 println(w)

--- a/tests/test_decl_error.kn
+++ b/tests/test_decl_error.kn
@@ -1,0 +1,1 @@
+something = 2

--- a/tests/test_floats.kn
+++ b/tests/test_floats.kn
@@ -1,8 +1,8 @@
-a = 3.14
+let a = 3.14
 println(a)
 
-b = 2.5 + 1.5
+let b = 2.5 + 1.5
 println(b)
 
-c = 10 / 4
+let c = 10 / 4
 println(c)

--- a/tests/test_if_else.kn
+++ b/tests/test_if_else.kn
@@ -1,4 +1,4 @@
-x = 5
+let x = 5
 if x == 5 {
     println('equal')
 } else {

--- a/tests/test_null.kn
+++ b/tests/test_null.kn
@@ -1,2 +1,2 @@
-x = null
+let x = null
 println(x)

--- a/tests/test_variables.kn
+++ b/tests/test_variables.kn
@@ -1,12 +1,12 @@
-x = 5
+let x = 5
 println(x)
 
-y = 'hello'
+let y = 'hello'
 println(y)
 
-x = 10
+let x = 10
 println(x)
 
-a = 2
-b = 3
+let a = 2
+let b = 3
 println(a + b)

--- a/tests/test_while.kn
+++ b/tests/test_while.kn
@@ -1,10 +1,10 @@
-i = 0
+let i = 0
 while i < 5 {
     println(i)
     i += 1
 }
 
-j = 0
+let j = 0
 while j < 3 {
     println(j)
     j = j + 1


### PR DESCRIPTION
Checklist:
- [x] Add let
- [x] Refactor old code
- [x] Make error codes for undeclared variables

Resolves #81 

## Summary by Sourcery

Introduce explicit variable declarations with a new `let` keyword, refactor function and export handling to use declaration nodes, and tighten compiler/runtime error reporting for undeclared variables and stack traces.

New Features:
- Add a `let` keyword and corresponding declaration AST node for explicit variable declarations.
- Include function names in function objects and emitted bytecode for better diagnostics and tooling.

Bug Fixes:
- Prevent assignment to undeclared variables by emitting a compile-time error instead of implicitly declaring them.
- Fix unary logical not constant folding to operate on the boolean value rather than the node object.
- Show all VM stack frames in error reporting instead of iterating them in reverse, and print the error code and message at the end.

Enhancements:
- Refactor assignments and exports to separate declaration (`Declare`) from reassignment (`Assign`) in the parser and compiler.
- Adjust export semantics so only declarations with values and functions are exportable, and treat exported declarations as proper declarations in the compiler.
- Tighten constant folding and compiler utilities, including helper methods for setting and declaring locals and minor whitespace/formatting cleanups.

Documentation:
- Update language and error documentation to describe `let` declarations, new export rules, and undeclared-variable behavior, and modernize examples to use `let`.

Tests:
- Add tests for closures and for assigning into arrays/dicts to validate the new declaration semantics and runtime behavior.