### PR TITLE
Add constant variables

### DIFF
--- a/specs/documentation/errors.md
+++ b/specs/documentation/errors.md
@@ -197,6 +197,22 @@ Used when the compiler finds an area where you attempt to multiply a string by a
 println('*' * -2)
 ```
 
+### 21: Value cannot be constant folded
+
+Used when you use a value that cannot be embedded in the constant pool in a constant value:
+
+```koniscript
+const foo = [] # Arrays cannot be constant folded
+```
+
+Note that koniscript constant folds these values, so:
+
+```koniscript
+const foo = 2 * 2
+```
+
+will work
+
 ## Runtime (VM) errors
 
 This section is for errors raised by the runtime (`kovm`)

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
-from calendar import c
 from dataclasses import dataclass
-from operator import truediv
-from typing import Any, Collection, Generator, Literal, assert_never, cast
+from typing import Any, Collection, Generator, Literal, assert_never
 from koni_compiler import base_env
 from koni_compiler.runtime import (
     T_BOOL,
@@ -2685,7 +2683,7 @@ class Compiler:
                 )
             
             idx = self.add_constant_for_node(val)
-            self.declare_local(node.name, ConstValue(node.line, node.col, node.end_line, node.end_col, idx))
+            self.declare_local(node.name, ConstValue(node.line, node.col, node.end_line, node.end_col, idx)) # pyright: ignore[reportArgumentType]
         elif isinstance(node, Declare):
             yield from self.compile_declare(node)
 

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -2636,7 +2636,7 @@ class Compiler:
             if idx[1] == 'user':
                 o = self.get_var_obj(node.name)
                 if o is not None and isinstance(o[0], self.ScopeItem) and isinstance(o[0].value, ConstValue):
-                    self.emit(node.line, 'PUSH_CONST', o[0].idx)
+                    self.emit(node.line, OP_PUSH_CONST, o[0].idx)
                 else:
                     self.emit(node.line, OP_GET_VAR, idx[0], idx[2])  # RETRIEVE idx depth
             else:
@@ -3020,7 +3020,7 @@ class Compiler:
             yield from self.compile_ins(node.body)
 
             self.emit(
-                node.line, 'PUSH_CONST', self.add_constant((base_env.T_NULL, None))
+                node.line, OP_PUSH_CONST, self.add_constant((base_env.T_NULL, None))
             )
             self.emit(node.line, 'RET')
 

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+from calendar import c
 from dataclasses import dataclass
-from typing import Any, Collection, Generator, Literal, assert_never
+from operator import truediv
+from typing import Any, Collection, Generator, Literal, assert_never, cast
 from koni_compiler import base_env
 from koni_compiler.runtime import (
     T_BOOL,
@@ -79,6 +81,7 @@ class TokenType(Enum):
     FStringEnd = 'FStringEnd'
     CONTINUE = 'CONTINUE'
     LET = 'LET'
+    CONST = 'CONST'
 
 
 PRECEDENCE = {
@@ -134,6 +137,7 @@ KEYWORDS = {
     'break': TokenType.BREAK,
     'continue': TokenType.CONTINUE,
     'let': TokenType.LET,
+    'const': TokenType.CONST
 }
 
 
@@ -1463,7 +1467,13 @@ class Parser:
                 end_line = name.end_line
                 end_col = name.end_col
             return Declare(let.line, let.col, end_line, end_col, name.value, val)
-
+        elif self.current_token.type == TokenType.CONST:
+            const = self.eat(TokenType.CONST)
+            name = self.eat(TokenType.IDENTIFIER).value
+            self.eat(TokenType.ASSIGN)
+            expr = yield from self.expr()
+            return Const(const.line, const.col, expr.end_line, expr.end_col, name, expr)
+        
         e = yield from self.expr()
 
         if self.current_token.type in (
@@ -1840,6 +1850,14 @@ class Declare(ASTNode):
     name: str
     value: ASTNode | None
 
+@dataclass
+class Const(ASTNode):
+    name: str
+    value: ASTNode
+
+@dataclass
+class ConstValue(ASTNode):
+    idx: int
 
 @dataclass
 class String(ASTNode):
@@ -2218,8 +2236,29 @@ def fold_node(node: ASTNode, fp: str) -> ASTNode:
                     assert_never(node.op)
 
     return node
+def can_be_constant(node: ASTNode):
+    match node:
+        case String() | Number() | Float() | Bool() | Null():
+            return True
+        case _:
+            return False
 
-
+def get_type_id(node: ASTNode) -> int | None:
+    match node:
+        case Number():
+            return 1
+        case String():
+            return 2
+        case Bool():
+            return 3
+        case Function():
+            return 4
+        case Null():
+            return 6
+        case Float():
+            return 7
+        case Array():
+            return 9
 class Compiler:
     def __init__(
         self,
@@ -2536,25 +2575,43 @@ class Compiler:
         if dup:
             self.emit(node.line, 'DUP')
         self.emit(node.line, OP_SET_VAR, idx, 0)
-
-    def compile_ins(
-        self, node: ASTNode, *other
-    ) -> Generator[CompilerWarn | ModuleRequest, ModuleReceived | None, Any]:
-        node = fold_node(node, self.mod_stack[-1].fp)
+    def add_constant_for_node(self, node):
         if isinstance(node, String):
             idx = self.add_constant([T_STRING, node.value])
             self.emit(node.line, OP_PUSH_CONST, idx)
         elif isinstance(node, Number):
             idx = self.add_constant([T_INT, node.value])
             self.emit(node.line, OP_PUSH_CONST, idx)
+        elif isinstance(node, Bool):
+            idx = self.add_constant([T_BOOL, 'true' if node.value else 'false'])
+            self.emit(node.line, OP_PUSH_CONST, idx)
         elif isinstance(node, Float):
             idx = self.add_constant([T_FLOAT, node.value])
             self.emit(node.line, OP_PUSH_CONST, idx)
-        elif isinstance(node, BareRequire):
-            self.reqs += node.reqs
         elif isinstance(node, Null):
             idx = self.add_constant([T_NULL, ''])
             self.emit(node.line, OP_PUSH_CONST, idx)
+        else:
+            return None
+        return idx
+
+
+    def compile_ins(
+        self, node: ASTNode, *other
+    ) -> Generator[CompilerWarn | ModuleRequest, ModuleReceived | None, Any]:
+        node = fold_node(node, self.mod_stack[-1].fp)
+        if isinstance(node, String):
+            self.add_constant_for_node(node)
+        elif isinstance(node, Number):
+            self.add_constant_for_node(node)
+        elif isinstance(node, Bool):
+            self.add_constant_for_node(node)
+        elif isinstance(node, Float):
+            self.add_constant_for_node(node)
+        elif isinstance(node, BareRequire):
+            self.reqs += node.reqs
+        elif isinstance(node, Null):
+            self.add_constant_for_node(node)
         elif isinstance(node, RequireStatement):
             consts: list[int] = []
             for item in node.reqs:
@@ -2588,7 +2645,11 @@ class Compiler:
                     self.mod_stack[-1].fp,
                 )
             if idx[1] == 'user':
-                self.emit(node.line, OP_GET_VAR, idx[0], idx[2])  # RETRIEVE idx depth
+                o = self.get_var_obj(node.name)
+                if o is not None and isinstance(o[0], self.ScopeItem) and isinstance(o[0].value, ConstValue):
+                    self.emit(node.line, 'PUSH_CONST', o[0].idx)
+                else:
+                    self.emit(node.line, OP_GET_VAR, idx[0], idx[2])  # RETRIEVE idx depth
             else:
                 if node.name == '_name':
                     yield from self.raise_for_req(
@@ -2609,16 +2670,23 @@ class Compiler:
                     self.mod_stack[-1].fp,
                 )
             self.emit(node.line, OP_SET_VAR, s[1], s[0])
-
+        elif isinstance(node, Const):
+            val = fold_node(node.value, self.mod_stack[-1].fp)
+            
+            if not can_be_constant(val):
+                raise CompilerError(
+                    -4, # TODO
+                    'This value cannot be folded into a constant',
+                    node.value.line,
+                    node.value.col,
+                    node.value.end_line,
+                    node.value.end_col,
+                    self.mod_stack[-1].fp,
+                )
+            
+            idx = self.add_constant_for_node(val)
+            self.declare_local(node.name, ConstValue(node.line, node.col, node.end_line, node.end_col, idx))
         elif isinstance(node, Declare):
-            # v = (
-            #     node.value
-            #     if node.value is not None
-            #     else Null(node.line, node.col, node.end_line, node.end_col)
-            # )
-            # yield from self.compile_ins(v)
-            # idx = self.declare_local(node.name, v)
-            # self.emit(node.line, OP_SET_VAR, idx, 0)
             yield from self.compile_declare(node)
 
         elif isinstance(node, BinOp):
@@ -2631,9 +2699,6 @@ class Compiler:
         elif isinstance(node, Block):
             for statement in node.statements:
                 yield from self.compile_ins(statement)
-        elif isinstance(node, Bool):
-            idx = self.add_constant([T_BOOL, 'true' if node.value else 'false'])
-            self.emit(node.line, OP_PUSH_CONST, idx)
         elif isinstance(node, Call):
             # compile the expression that identifies the callable (variable, attribute, etc.)
             yield from self.compile_ins(node.func)

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -2000,22 +2000,6 @@ def can_be_constant(node: ASTNode):
         case _:
             return False
 
-def get_type_id(node: ASTNode) -> int | None:
-    match node:
-        case Number():
-            return 1
-        case String():
-            return 2
-        case Bool():
-            return 3
-        case Function():
-            return 4
-        case Null():
-            return 6
-        case Float():
-            return 7
-        case Array():
-            return 9
 class Compiler:
     def __init__(
         self,

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -1856,6 +1856,7 @@ class Const(ASTNode):
 @dataclass
 class ConstValue(ASTNode):
     idx: int
+    value: ASTNode
 
 @dataclass
 class String(ASTNode):
@@ -1992,248 +1993,6 @@ class FoldingError(CompilationException):
         super().__init__(code, msg, line, col, end_line, end_col, fp)
 
 
-def fold_node(node: ASTNode, fp: str) -> ASTNode:
-    def add(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-        match a, b:
-            case (Number(), Number()):
-                return Number(s.line, s.col, s.end_line, s.end_col, a.value + b.value)
-            case (String(), String()):
-                return String(s.line, s.col, s.end_line, s.end_col, a.value + b.value)
-            case (Float(), Float()):
-                return Float(s.line, s.col, s.end_line, s.end_col, a.value + b.value)
-            case (Float(), Number()) | (Number(), Float()):
-                return Float(s.line, s.col, s.end_line, s.end_col, a.value + b.value)
-        return node
-
-    def sub(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-        match a, b:
-            case (Number(), Number()):
-                return Number(s.line, s.col, s.end_line, s.end_col, a.value - b.value)
-            case (Float(), Number()) | (Number(), Float()) | (Float(), Float()):
-                return Float(s.line, s.col, s.end_line, s.end_col, a.value - b.value)
-        return s
-
-    def div(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-
-        match a, b:
-            case (Number(), Number()):
-                if b.value == 0:
-                    raise FoldingError(s, fp, FER.DivByZero)
-                return Float(s.line, s.col, s.end_line, s.end_col, a.value / b.value)
-            case (Float(), Number()) | (Number(), Float()) | (Float(), Float()):
-                if b.value == 0:
-                    raise FoldingError(s, fp, FER.DivByZero)
-                return Float(s.line, s.col, s.end_line, s.end_col, a.value / b.value)
-        return s
-
-    def mul(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-        match a, b:
-            case (Number(), Number()):
-                return Number(s.line, s.col, s.end_line, s.end_col, a.value * b.value)
-            case (Float(), Number()) | (Number(), Float()) | (Float(), Float()):
-                return Float(s.line, s.col, s.end_line, s.end_col, a.value * b.value)
-            case (String(), Number()):
-                if b.value < 0:
-                    raise FoldingError(s, fp, FER.MulStrByNeg)
-                return String(s.line, s.col, s.end_line, s.end_col, a.value * b.value)
-        return s
-
-    def mod(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-
-        match a, b:
-            case (Number(), Number()):
-                if b.value == 0:
-                    raise FoldingError(s, fp, FER.DivByZero)
-                return Number(s.line, s.col, s.end_line, s.end_col, a.value % b.value)
-            case (Float(), Number()) | (Number(), Float()) | (Float(), Float()):
-                if b.value == 0:
-                    raise FoldingError(s, fp, FER.DivByZero)
-                return Float(s.line, s.col, s.end_line, s.end_col, a.value % b.value)
-        return s
-
-    def or_(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-
-        match a, b:
-            case (Bool(), Bool()):
-                return Bool(s.line, s.col, s.end_line, s.end_col, a.value or b.value)
-        return s
-
-    def and_(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-
-        match a, b:
-            case (Bool(), Bool()):
-                return Bool(s.line, s.col, s.end_line, s.end_col, a.value and b.value)
-        return s
-
-    def eq(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-
-        match a, b:
-            case (
-                (Number(), Number())
-                | (Number(), Float())
-                | (Float(), Number())
-                | (Float(), Float())
-                | (Bool(), Bool())
-            ):
-                return Bool(s.line, s.col, s.end_line, s.end_col, a.value == b.value)
-        return s
-
-    def neq(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-
-        match a, b:
-            case (
-                (Number(), Number())
-                | (Number(), Float())
-                | (Float(), Number())
-                | (Float(), Float())
-                | (Bool(), Bool())
-            ):
-                return Bool(s.line, s.col, s.end_line, s.end_col, a.value != b.value)
-        return s
-
-    def pow(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-
-        match a, b:
-            case (Number(), Number()):
-                return Number(s.line, s.col, s.end_line, s.end_col, a.value**b.value)
-            case (Number(), Float()) | (Float(), Number()) | (Float(), Float()):
-                return Float(s.line, s.col, s.end_line, s.end_col, a.value**b.value)
-        return s
-
-    def lt(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-
-        match a, b:
-            case (Number(), Number()):
-                return Bool(s.line, s.col, s.end_line, s.end_col, a.value < b.value)
-            case (Number(), Float()) | (Float(), Number()) | (Float(), Float()):
-                return Bool(s.line, s.col, s.end_line, s.end_col, a.value < b.value)
-        return s
-
-    def lte(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-
-        match a, b:
-            case (
-                (Number(), Number())
-                | (Number(), Float())
-                | (Float(), Number())
-                | (Float(), Float())
-            ):
-                return Bool(s.line, s.col, s.end_line, s.end_col, a.value <= b.value)
-        return s
-
-    def gt(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-
-        match a, b:
-            case (
-                (Number(), Number())
-                | (Number(), Float())
-                | (Float(), Number())
-                | (Float(), Float())
-            ):
-                return Bool(s.line, s.col, s.end_line, s.end_col, a.value > b.value)
-        return s
-
-    def gte(s: BinOp) -> ASTNode:
-        a = s.left
-        b = s.right
-
-        match a, b:
-            case (
-                (Number(), Number())
-                | (Number(), Float())
-                | (Float(), Number())
-                | (Float(), Float())
-            ):
-                return Bool(s.line, s.col, s.end_line, s.end_col, a.value >= b.value)
-        return s
-
-    def neg(s: UnaryOp) -> ASTNode:
-        match s.right:
-            case Number():
-                return Number(s.line, s.col, s.end_line, s.end_col, 0 - s.right.value)
-            case Float():
-                return Float(s.line, s.col, s.end_line, s.end_col, 0 - s.right.value)
-        return s
-
-    def not_(s: UnaryOp) -> ASTNode:
-        match s.right:
-            case Bool():
-                return Bool(s.line, s.col, s.end_line, s.end_col, not s.right.value)
-        return s
-
-    match node:
-        case BinOp():
-            node.left = fold_node(node.left, fp)
-            node.right = fold_node(node.right, fp)
-            match node.op:
-                case BinOpType.ADD:
-                    return add(node)
-                case BinOpType.SUB:
-                    return sub(node)
-                case BinOpType.DIV:
-                    return div(node)
-                case BinOpType.MUL:
-                    return mul(node)
-                case BinOpType.MOD:
-                    return mod(node)
-                case BinOpType.LT:
-                    return lt(node)
-                case BinOpType.GT:
-                    return gt(node)
-                case BinOpType.LTE:
-                    return lte(node)
-                case BinOpType.GTE:
-                    return gte(node)
-                case BinOpType.OR:
-                    return or_(node)
-                case BinOpType.AND:
-                    return and_(node)
-                case BinOpType.POW:
-                    return pow(node)
-                case BinOpType.EQ:
-                    return eq(node)
-                case BinOpType.NEQ:
-                    return neq(node)
-                case _:
-                    assert_never(node.op)
-        case UnaryOp():
-            node.right = fold_node(node.right, fp)
-
-            match node.op:
-                case UnaryOpType.NEG:
-                    return neg(node)
-                case UnaryOpType.NOT:
-                    return not_(node)
-                case _:
-                    assert_never(node.op)
-
-    return node
 def can_be_constant(node: ASTNode):
     match node:
         case String() | Number() | Float() | Bool() | Null():
@@ -2423,6 +2182,254 @@ class Compiler:
             if item == fp:
                 self.source_info.append(i)
         return idx
+    def fold_node(self, node: ASTNode, fp: str) -> ASTNode:
+        def add(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+            match a, b:
+                case (Number(), Number()):
+                    return Number(s.line, s.col, s.end_line, s.end_col, a.value + b.value)
+                case (String(), String()):
+                    return String(s.line, s.col, s.end_line, s.end_col, a.value + b.value)
+                case (Float(), Float()):
+                    return Float(s.line, s.col, s.end_line, s.end_col, a.value + b.value)
+                case (Float(), Number()) | (Number(), Float()):
+                    return Float(s.line, s.col, s.end_line, s.end_col, a.value + b.value)
+            return node
+
+        def sub(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+            match a, b:
+                case (Number(), Number()):
+                    return Number(s.line, s.col, s.end_line, s.end_col, a.value - b.value)
+                case (Float(), Number()) | (Number(), Float()) | (Float(), Float()):
+                    return Float(s.line, s.col, s.end_line, s.end_col, a.value - b.value)
+            return s
+
+        def div(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+
+            match a, b:
+                case (Number(), Number()):
+                    if b.value == 0:
+                        raise FoldingError(s, fp, FER.DivByZero)
+                    return Float(s.line, s.col, s.end_line, s.end_col, a.value / b.value)
+                case (Float(), Number()) | (Number(), Float()) | (Float(), Float()):
+                    if b.value == 0:
+                        raise FoldingError(s, fp, FER.DivByZero)
+                    return Float(s.line, s.col, s.end_line, s.end_col, a.value / b.value)
+            return s
+
+        def mul(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+            match a, b:
+                case (Number(), Number()):
+                    return Number(s.line, s.col, s.end_line, s.end_col, a.value * b.value)
+                case (Float(), Number()) | (Number(), Float()) | (Float(), Float()):
+                    return Float(s.line, s.col, s.end_line, s.end_col, a.value * b.value)
+                case (String(), Number()):
+                    if b.value < 0:
+                        raise FoldingError(s, fp, FER.MulStrByNeg)
+                    return String(s.line, s.col, s.end_line, s.end_col, a.value * b.value)
+            return s
+
+        def mod(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+
+            match a, b:
+                case (Number(), Number()):
+                    if b.value == 0:
+                        raise FoldingError(s, fp, FER.DivByZero)
+                    return Number(s.line, s.col, s.end_line, s.end_col, a.value % b.value)
+                case (Float(), Number()) | (Number(), Float()) | (Float(), Float()):
+                    if b.value == 0:
+                        raise FoldingError(s, fp, FER.DivByZero)
+                    return Float(s.line, s.col, s.end_line, s.end_col, a.value % b.value)
+            return s
+
+        def or_(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+
+            match a, b:
+                case (Bool(), Bool()):
+                    return Bool(s.line, s.col, s.end_line, s.end_col, a.value or b.value)
+            return s
+
+        def and_(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+
+            match a, b:
+                case (Bool(), Bool()):
+                    return Bool(s.line, s.col, s.end_line, s.end_col, a.value and b.value)
+            return s
+
+        def eq(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+
+            match a, b:
+                case (
+                    (Number(), Number())
+                    | (Number(), Float())
+                    | (Float(), Number())
+                    | (Float(), Float())
+                    | (Bool(), Bool())
+                ):
+                    return Bool(s.line, s.col, s.end_line, s.end_col, a.value == b.value)
+            return s
+
+        def neq(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+
+            match a, b:
+                case (
+                    (Number(), Number())
+                    | (Number(), Float())
+                    | (Float(), Number())
+                    | (Float(), Float())
+                    | (Bool(), Bool())
+                ):
+                    return Bool(s.line, s.col, s.end_line, s.end_col, a.value != b.value)
+            return s
+
+        def pow(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+
+            match a, b:
+                case (Number(), Number()):
+                    return Number(s.line, s.col, s.end_line, s.end_col, a.value**b.value)
+                case (Number(), Float()) | (Float(), Number()) | (Float(), Float()):
+                    return Float(s.line, s.col, s.end_line, s.end_col, a.value**b.value)
+            return s
+
+        def lt(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+
+            match a, b:
+                case (Number(), Number()):
+                    return Bool(s.line, s.col, s.end_line, s.end_col, a.value < b.value)
+                case (Number(), Float()) | (Float(), Number()) | (Float(), Float()):
+                    return Bool(s.line, s.col, s.end_line, s.end_col, a.value < b.value)
+            return s
+
+        def lte(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+
+            match a, b:
+                case (
+                    (Number(), Number())
+                    | (Number(), Float())
+                    | (Float(), Number())
+                    | (Float(), Float())
+                ):
+                    return Bool(s.line, s.col, s.end_line, s.end_col, a.value <= b.value)
+            return s
+
+        def gt(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+
+            match a, b:
+                case (
+                    (Number(), Number())
+                    | (Number(), Float())
+                    | (Float(), Number())
+                    | (Float(), Float())
+                ):
+                    return Bool(s.line, s.col, s.end_line, s.end_col, a.value > b.value)
+            return s
+
+        def gte(s: BinOp) -> ASTNode:
+            a = s.left
+            b = s.right
+
+            match a, b:
+                case (
+                    (Number(), Number())
+                    | (Number(), Float())
+                    | (Float(), Number())
+                    | (Float(), Float())
+                ):
+                    return Bool(s.line, s.col, s.end_line, s.end_col, a.value >= b.value)
+            return s
+
+        def neg(s: UnaryOp) -> ASTNode:
+            match s.right:
+                case Number():
+                    return Number(s.line, s.col, s.end_line, s.end_col, 0 - s.right.value)
+                case Float():
+                    return Float(s.line, s.col, s.end_line, s.end_col, 0 - s.right.value)
+            return s
+
+        def not_(s: UnaryOp) -> ASTNode:
+            match s.right:
+                case Bool():
+                    return Bool(s.line, s.col, s.end_line, s.end_col, not s.right.value)
+            return s
+
+        match node:
+            case BinOp():
+                node.left = self.fold_node(node.left, fp)
+                node.right = self.fold_node(node.right, fp)
+                match node.op:
+                    case BinOpType.ADD:
+                        return add(node)
+                    case BinOpType.SUB:
+                        return sub(node)
+                    case BinOpType.DIV:
+                        return div(node)
+                    case BinOpType.MUL:
+                        return mul(node)
+                    case BinOpType.MOD:
+                        return mod(node)
+                    case BinOpType.LT:
+                        return lt(node)
+                    case BinOpType.GT:
+                        return gt(node)
+                    case BinOpType.LTE:
+                        return lte(node)
+                    case BinOpType.GTE:
+                        return gte(node)
+                    case BinOpType.OR:
+                        return or_(node)
+                    case BinOpType.AND:
+                        return and_(node)
+                    case BinOpType.POW:
+                        return pow(node)
+                    case BinOpType.EQ:
+                        return eq(node)
+                    case BinOpType.NEQ:
+                        return neq(node)
+                    case _:
+                        assert_never(node.op)
+            case UnaryOp():
+                node.right = self.fold_node(node.right, fp)
+
+                match node.op:
+                    case UnaryOpType.NEG:
+                        return neg(node)
+                    case UnaryOpType.NOT:
+                        return not_(node)
+                    case _:
+                        assert_never(node.op)
+            case Variable():
+                o = self.get_var_obj(node.name)
+                if o is None:
+                    return node
+                if isinstance(o[0], self.ScopeItem) and isinstance(o[0].value, ConstValue):
+                    return o[0].value.value
+
+        return node
 
     def compile(
         self,
@@ -2597,7 +2604,7 @@ class Compiler:
     def compile_ins(
         self, node: ASTNode, *other
     ) -> Generator[CompilerWarn | ModuleRequest, ModuleReceived | None, Any]:
-        node = fold_node(node, self.mod_stack[-1].fp)
+        node = self.fold_node(node, self.mod_stack[-1].fp)
         if isinstance(node, String):
             self.add_constant_for_node(node)
         elif isinstance(node, Number):
@@ -2669,11 +2676,11 @@ class Compiler:
                 )
             self.emit(node.line, OP_SET_VAR, s[1], s[0])
         elif isinstance(node, Const):
-            val = fold_node(node.value, self.mod_stack[-1].fp)
+            val = self.fold_node(node.value, self.mod_stack[-1].fp)
             
             if not can_be_constant(val):
                 raise CompilerError(
-                    -4, # TODO
+                    21,
                     'This value cannot be folded into a constant',
                     node.value.line,
                     node.value.col,
@@ -2683,7 +2690,7 @@ class Compiler:
                 )
             
             idx = self.add_constant_for_node(val)
-            self.declare_local(node.name, ConstValue(node.line, node.col, node.end_line, node.end_col, idx)) # pyright: ignore[reportArgumentType]
+            self.declare_local(node.name, ConstValue(node.line, node.col, node.end_line, node.end_col, idx, val)) # pyright: ignore[reportArgumentType]
         elif isinstance(node, Declare):
             yield from self.compile_declare(node)
 
@@ -2963,7 +2970,7 @@ class Compiler:
             jmps = True
             compelse = True
             compif = True
-            node.expr = fold_node(node.expr, self.mod_stack[-1].fp)
+            node.expr = self.fold_node(node.expr, self.mod_stack[-1].fp)
             if not isinstance(node.expr, Bool):
                 yield from self.compile_ins(node.expr)
                 jmp = self.emit(node.line, 'JMPIFF', None)


### PR DESCRIPTION
Resolves #92

## Summary by Sourcery

Add support for constant variables, integrate them into constant folding and code generation, and document the new compile-time error for non-foldable constant values.

New Features:
- Introduce a CONST keyword, parser rule, and AST nodes to declare and represent constant variables.
- Allow constant variables to be stored in and loaded from the constant pool for more efficient access.

Enhancements:
- Move expression constant folding into the Compiler class and extend it to resolve variables bound to constant values during folding.
- Refactor constant emission into a helper to centralize adding primitive literals to the constant pool.

Documentation:
- Document compile-time error 21 for values that cannot be folded into constants.