### PR TITLE
Make blocks have their own scope + add bare blocks

### DIFF
--- a/kovm/src/runtime.rs
+++ b/kovm/src/runtime.rs
@@ -31,6 +31,7 @@ pub struct Env {
     pub values: Vec<Option<Value>>,
     pub parent: Option<Rc<RefCell<Env>>>,
     pub exports: HashMap<String, Export>,
+    pub markers: Vec<usize>
 }
 
 impl PartialEq for Env {

--- a/kovm/src/vm.rs
+++ b/kovm/src/vm.rs
@@ -126,6 +126,7 @@ impl Frame {
                 parent: None,
                 values: vec![],
                 exports: HashMap::new(),
+                markers: vec![]
             })),
             ret_addr: None,
             stack: vec![],
@@ -332,6 +333,7 @@ impl VM {
             values: vec![None; local_count.unwrap() as usize],
             parent: None,
             exports: HashMap::new(),
+            markers: vec![]
         })));
 
         let content = if let Some(x) = sup_lines {
@@ -436,6 +438,7 @@ impl VM {
                     values: vec![None; *local_count],
                     parent: Some(Rc::clone(closure)),
                     exports: HashMap::new(),
+                    markers: vec![]
                 }));
                 let mut rust_args: Vec<Option<Value>> = vec![];
                 for arg in args {
@@ -531,10 +534,7 @@ impl VM {
                     Value::Bool(v) => v,
                     _ => {
                         return Err(VmError {
-                            msg: format!(
-                                "expected a boolean but got a {}",
-                                condv.display()
-                            ),
+                            msg: format!("expected a boolean but got a {}", condv.display()),
                             errcode: ErrCode::TypeError,
                         });
                     }
@@ -562,10 +562,7 @@ impl VM {
                     Value::Bool(v) => v,
                     _ => {
                         return Err(VmError {
-                            msg: format!(
-                                "expected a boolean but got a {}",
-                                condv.display()
-                            ),
+                            msg: format!("expected a boolean but got a {}", condv.display()),
                             errcode: ErrCode::TypeError,
                         });
                     }
@@ -639,10 +636,10 @@ impl VM {
                 self.push_to_stack(to_push);
             }
             "BREAK" => {
-                println!("Breakpoint: at {}:", self.frames.last().unwrap().name);
-                println!("Stack : {:#?}", self.frames.last().unwrap().stack);
+                eprintln!("Breakpoint: at {}:", self.frames.last().unwrap().name);
+                eprintln!("Stack : {:#?}", self.frames.last().unwrap().stack);
                 let mut b = String::new();
-                print!("Press enter to continue");
+                eprint!("Press enter to continue");
                 let _ = std::io::stdin().read_line(&mut b);
             }
             "GETATTR" => {
@@ -743,6 +740,22 @@ impl VM {
                     }
                 };
                 self.frames.last_mut().unwrap().stack.push(out);
+            }
+            "ENTER_SCOPE" => {
+                let mut l: usize = 0;
+                for item in &self.frames.last().unwrap().env.borrow().values {
+                    if item.is_some() {
+                        l += 1;
+                    }
+                }
+                self.frames.last_mut().unwrap().env.borrow_mut().markers.push(l);
+            }
+            "EXIT_SCOPE" => {
+                let l = self.frames.last().unwrap().env.borrow().values.len();
+                let m = self.frames.last().unwrap().env.borrow_mut().markers.pop().unwrap();
+                for idx in m..l {
+                    self.frames.last().unwrap().env.borrow_mut().values[idx] = None;
+                }
             }
             "GET_ITEM" => {
                 let item = self.pop_from_stack()?;

--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -1441,6 +1441,8 @@ class Parser:
             self.eat(TokenType.IMPORT)
             name_tok = self.eat(TokenType.IDENTIFIER)
             return Import(ln, col, name_tok.end_line, name_tok.end_col, name_tok.value)
+        elif self.current_token.type == TokenType.LBRACE:
+            return (yield from self.block())
         elif self.current_token.type == TokenType.RETURN:
             ln = self.current_token.line
             col = self.current_token.col
@@ -2083,6 +2085,7 @@ class Compiler:
             )
 
             self.next_local = len(self.var_map)
+            self.local_count = len(self.var_map)
             self.args = args if args is not None else {}
 
     @dataclass
@@ -2132,6 +2135,7 @@ class Compiler:
         scope.var_map[name] = Compiler.ScopeItem(index, value)
         scope.next_local += 1
         self.var_count += 1
+        scope.local_count += 1
 
         return index
 
@@ -2457,7 +2461,7 @@ class Compiler:
         if len(self.reqs) > 0:
             output.append('.reqs ' + ' '.join([str(x) for x in self.reqs]))
 
-        output.append(f'.frame {self.scopes[0].next_local}')
+        output.append(f'.frame {self.scopes[0].local_count}')
 
         output.append('.const')
         for const in self.constants:
@@ -2584,7 +2588,17 @@ class Compiler:
             return None
         return idx
 
-
+    def compile_block(self, block: Block, create_scope: bool):
+        if create_scope:
+            self.emit(block.line, 'ENTER_SCOPE')
+            old_map = self.scopes[-1].var_map.copy()
+            old_nl = self.scopes[-1].next_local
+        for stmnt in block.statements:
+            yield from self.compile_ins(stmnt)
+        if create_scope:
+            self.emit(block.end_line, 'EXIT_SCOPE')
+            self.scopes[-1].next_local = old_nl # pyright: ignore[reportPossiblyUnboundVariable]
+            self.scopes[-1].var_map = old_map # pyright: ignore[reportPossiblyUnboundVariable]
     def compile_ins(
         self, node: ASTNode, *other
     ) -> Generator[CompilerWarn | ModuleRequest, ModuleReceived | None, Any]:
@@ -2686,8 +2700,7 @@ class Compiler:
             yield from self.compile_ins(node.right)
             self.emit(node.line, OpcodeType(node.op))
         elif isinstance(node, Block):
-            for statement in node.statements:
-                yield from self.compile_ins(statement)
+            yield from self.compile_block(node, True)
         elif isinstance(node, Call):
             # compile the expression that identifies the callable (variable, attribute, etc.)
             yield from self.compile_ins(node.func)
@@ -3017,14 +3030,14 @@ class Compiler:
             self.enter_scope({})
             for param in node.params:
                 self.declare_local(param.name, param)
-            yield from self.compile_ins(node.body)
+            yield from self.compile_block(node.body, False)
 
             self.emit(
                 node.line, OP_PUSH_CONST, self.add_constant((base_env.T_NULL, None))
             )
             self.emit(node.line, 'RET')
 
-            local_count = self.scopes[-1].next_local
+            local_count = self.scopes[-1].local_count
             self.exit_scope()
             self.code[jmp] = ('JMP', len(self.code))
             idx = self.add_constant([T_STRING, node.name])
@@ -3125,6 +3138,7 @@ class Compiler:
             self.emit(node.line, 'MAKE_MODULE', idx)
             md = self.mod_stack.pop()
             self.scopes[0].next_local += 1  # TODO: make this better
+            self.scopes[0].local_count += 1
             yield from self.compile_declare(
                 Declare(node.line, node.col, node.end_line, node.end_col, node.mod, md)
             )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -50,6 +50,10 @@ def test_if_else():
     out = koni.run(TESTS / 'test_if_else.kn').stdout
     assert out == b'equal\nmedium\n'
 
+def test_block_scopes():
+    out = koni.run(TESTS / 'test_block_scopes.kn').stdout
+    assert out == b'5\n1\n2\n1\n'
+
 
 def test_while():
     out = koni.run(TESTS / 'test_while.kn').stdout

--- a/tests/test_block_scopes.kn
+++ b/tests/test_block_scopes.kn
@@ -1,0 +1,16 @@
+let i = 1
+
+if true {
+    let i = 5
+    println(i)
+}
+
+
+println(i)
+
+{
+    let i = 2
+    println(i)
+}
+
+println(i)


### PR DESCRIPTION
Resolves #83 
Resolves #82 

Makes each block have their own scope and allow bare blocks:

```koniscript
{
    let a = 5
}
println(a) # compile-time error
```

```koniscript
let a = 2
{
    let a = 5 # This uses let, so it doesn't modify the original variable
    println(a) # 5
}
println(a) # 2
```

## Summary by Sourcery

Introduce scoped blocks and bare block statements in the language and runtime.

New Features:
- Support bare block statements in the parser and compiler so blocks can appear as standalone statements.
- Add VM opcodes and compiler support to enter and exit lexical scopes within frames, giving each block its own variable scope.

Enhancements:
- Track local variable counts separately from next-local indices to correctly size frames and closures.
- Switch VM breakpoint logging to use standard error output instead of standard output.

Tests:
- Add coverage for block scoping behavior in the basic test suite.