### PR TITLE
Hoist function declarations to the top of their scope

### DIFF
--- a/src/koni_compiler/main.py
+++ b/src/koni_compiler/main.py
@@ -2418,6 +2418,12 @@ class Compiler:
                     return o[0].value.value
 
         return node
+    def decl_funcs(self, statements: list[ASTNode]):
+        for node in statements:
+            if isinstance(node, Declare) and isinstance(node.value, Function):
+                self.declare_local(node.name, node.value)
+            if isinstance(node, Export) and isinstance(node.lhs, Function):
+                self.declare_local(node.name, node.lhs)
 
     def compile(
         self,
@@ -2445,6 +2451,7 @@ class Compiler:
             self.sources[self.filepath] = (  # pyright: ignore[reportArgumentType]
                 input_source
             )
+        self.decl_funcs(program.statements)
         for node in program.statements:
             # empty statements (e.g. stray braces) may be None
             if node is None:
@@ -2562,7 +2569,12 @@ class Compiler:
         )
         if not isinstance(node.value, Function):
             yield from self.compile_ins(v)
-        idx = self.declare_local(node.name, v)
+            idx = self.declare_local(node.name, v)
+        else:
+            idx = self.get_var(node.name)
+            if idx is None:
+                raise CompilerError(13, '(internal) Function was not hoisted to the top of its scope. Report this bug to koniscript\'s bug tracker on GitHub', node.line, node.col, node.end_line, node.end_col, self.mod_stack[-1].fp)
+            idx = idx[0]
         if isinstance(node.value, Function):
             yield from self.compile_ins(v)
         if dup:
@@ -2593,6 +2605,7 @@ class Compiler:
             self.emit(block.line, 'ENTER_SCOPE')
             old_map = self.scopes[-1].var_map.copy()
             old_nl = self.scopes[-1].next_local
+        self.decl_funcs(block.statements)
         for stmnt in block.statements:
             yield from self.compile_ins(stmnt)
         if create_scope:
@@ -3131,6 +3144,7 @@ class Compiler:
             self.modules.append(node.mod)
             self.enter_scope()
             self.sources[module.filepath] = module.content
+            self.decl_funcs(module.program.statements)
             for statement in module.program.statements:
                 yield from self.compile_ins(statement)
             self.exit_scope()

--- a/tests/packages/test_func_hoisting.kn
+++ b/tests/packages/test_func_hoisting.kn
@@ -1,0 +1,19 @@
+export func main() {
+func is_even(n) {
+    if n == 0 {
+        return true
+    }
+    return is_odd(n - 1)
+}
+
+func is_odd(n) {
+    if n == 0 {
+        return false
+    }
+    return is_even(n - 1)
+}
+
+println(is_even(10))
+}
+
+main()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -121,3 +121,7 @@ def test_decl_error():
     with pytest.raises(SystemExit):
         out = koni.run(TESTS / 'test_decl_error.kn')
         assert out.returncode != 0
+
+def test_func_hoisting():
+    out = koni.run(TESTS / 'test_func_hoisting_import.kn').stdout
+    assert out == b'true\ntrue\n'

--- a/tests/test_func_hoisting_import.kn
+++ b/tests/test_func_hoisting_import.kn
@@ -1,0 +1,3 @@
+import test_func_hoisting
+
+test_func_hoisting.main()


### PR DESCRIPTION
Resolves #99 

Allows things like

```
func is_even(n) {
    if n == 0 {
        return true
    }
    return is_odd(n - 1)
}

func is_odd(n) {
    if n == 0 {
        return false
    }
    return is_even(n - 1)
}

println(is_even(10))
```

## Summary by Sourcery

Hoist function declarations to the top of their scope so functions are available throughout their enclosing program, block, and imported modules.

New Features:
- Support calling functions before their textual declaration within the same scope, including mutually recursive functions.

Bug Fixes:
- Fix failures when mutually recursive functions call each other before one is declared by ensuring their declarations are hoisted in the compiler.

Tests:
- Add tests verifying function hoisting across packages and when importing modules.