### PR TITLE
Add more IO builtins

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
         "corge",
         "ctypes",
         "datas",
+        "eflush",
         "endlocal",
         "enviornments",
         "fenv",

--- a/kovm/src/runtime.rs
+++ b/kovm/src/runtime.rs
@@ -631,11 +631,37 @@ pub fn vm_to_bool_basic(item: &Value, _vm: &mut VM) -> Result<Value, VmError> {
     Ok(Value::Bool(b))
 }
 pub fn vm_println(_vm: &mut VM, args: &[Value]) -> Result<Value, VmError> {
-    print_helper(_vm, args)?;
+    print_helper(_vm, args, false)?;
     println!();
     Ok(Value::Null)
 }
-fn print_helper(_vm: &mut VM, args: &[Value]) -> Result<(), VmError> {
+pub fn vm_eprintln(_vm: &mut VM, args: &[Value]) -> Result<Value, VmError> {
+    print_helper(_vm, args, true)?;
+    eprintln!();
+    Ok(Value::Null)
+}
+pub fn vm_flush(_vm: &mut VM, _args: &[Value]) -> Result<Value, VmError> {
+    let o = std::io::stdout().flush();
+    match o {
+        Err(_) => Err(VmError {
+            msg: "Failed to flush stdout".to_string(),
+            errcode: ErrCode::IoError
+        }),
+        Ok(_) => Ok(Value::Null)
+    }
+}
+pub fn vm_eflush(_vm: &mut VM, _args: &[Value]) -> Result<Value, VmError> {
+    let o = std::io::stderr().flush();
+    match o {
+        Err(_) => Err(VmError {
+            msg: "Failed to flush stderr".to_string(),
+            errcode: ErrCode::IoError
+        }),
+        Ok(_) => Ok(Value::Null)
+    }
+}
+
+fn print_helper(_vm: &mut VM, args: &[Value], e: bool) -> Result<(), VmError> {
     let mut rust_args: Vec<String> = Vec::new();
     for item in args {
         let out = vm_to_str(_vm, std::slice::from_ref(item));
@@ -653,18 +679,23 @@ fn print_helper(_vm: &mut VM, args: &[Value]) -> Result<(), VmError> {
             Err(e) => return Err(e),
         }
     }
-    print!("{}", rust_args.join(" "));
+    if e {
+        eprint!("{}", rust_args.join(" "));
+    } else {
+        print!("{}", rust_args.join(" "));
+    }
     Ok(())
 }
 pub fn vm_print(_vm: &mut VM, args: &[Value]) -> Result<Value, VmError> {
-    print_helper(_vm, args)?;
-    io::stdout().flush().map_err(|e| VmError {
-        msg: format!("Failed to flush stdout: {}", e),
-        errcode: ErrCode::IoError, // Or a specific I/O error code
-    })?;
-
+    print_helper(_vm, args, false)?;
     Ok(Value::Null)
 }
+
+pub fn vm_eprint(_vm: &mut VM, args: &[Value]) -> Result<Value, VmError> {
+    print_helper(_vm, args, true)?;
+    Ok(Value::Null)
+}
+
 pub fn vm_sleep(_vm: &mut VM, args: &[Value]) -> Result<Value, VmError> {
     let [s] = args else {
         return Err(VmError {
@@ -732,6 +763,22 @@ pub fn vmenv() -> Vec<Value> {
         Value::Func(Rc::new(KoniFunc::Builtin {
             name: "println".to_string(),
             func: vm_println,
+        })),
+        Value::Func(Rc::new(KoniFunc::Builtin {
+            name: "eprint".to_string(),
+            func: vm_eprint,
+        })),
+        Value::Func(Rc::new(KoniFunc::Builtin {
+            name: "eprintln".to_string(),
+            func: vm_eprintln,
+        })),
+        Value::Func(Rc::new(KoniFunc::Builtin {
+            name: "flush".to_string(),
+            func: vm_flush
+        })),
+        Value::Func(Rc::new(KoniFunc::Builtin {
+            name: "eflush".to_string(),
+            func: vm_eflush
         })),
         Value::Func(Rc::new(KoniFunc::Builtin {
             name: "sleep".to_string(),

--- a/src/koni_compiler/base_env.py
+++ b/src/koni_compiler/base_env.py
@@ -10,6 +10,10 @@ T_NULL = 6
 ASTenv: list[tuple[str, Builtin]] = [
     ('print', BuiltinFunction('print', 0, None)),
     ('println', BuiltinFunction('println', 0, None)),
+    ('eprint', BuiltinFunction('eprint', 0, None)),
+    ('eprintln', BuiltinFunction('eprintln', 0, None)),
+    ('flush', BuiltinFunction('flush', 0, 0)),
+    ('eflush', BuiltinFunction('eflush', 0, 0)),
     ('sleep', BuiltinFunction('sleep', 1, 1)),
     ('input', BuiltinFunction('input', 0, 1)),
     ('to_str', BuiltinFunction('to_str', 1, 1)),


### PR DESCRIPTION
Adds `eprint`, `eprintln`, and `flush`/`eflush` to print to stderr, and flush std(out/err) respectively

Resolves #107 
Resolves #106 
Resolves #103 