### PR TITLE
Make error displays shorter

### DIFF
--- a/koni_lsp/editors/vscode/src/extension.ts
+++ b/koni_lsp/editors/vscode/src/extension.ts
@@ -18,7 +18,7 @@ export function activate(context: ExtensionContext) {
     args: ['uv', "run", "server.py"],
     transport: TransportKind.stdio,
     options: {
-      cwd: "/home/ahmad/coding/OmniScript/koni_lsp",
+      cwd: "/home/ahmad/coding/koniscript/koni_lsp",
     },
   };
   let channel = window.createOutputChannel("koniscript LSP Trace");

--- a/src/koni_compiler/koni.py
+++ b/src/koni_compiler/koni.py
@@ -255,7 +255,7 @@ def show_err_or_warn(e: Failed | Warn):
         end_line = None
     if end_col == col:
         end_col = None
-    RADIUS = 5
+    RADIUS = 2
 
     eprint()
     eprint(f'<b>{tag}{end_color}: {msg}:')
@@ -306,7 +306,7 @@ def show_err_or_warn(e: Failed | Warn):
                 if not big:
                     eprint(f'<blue><b>{n: 7} |</b></blue> {lnc}')
                 else:
-                    if start + 4 > n or n > end-3:
+                    if start + 4 > n or n > end-4:
                         eprint(f'<blue><b>{n: 7} |</b></blue> {lnc}')
                     elif n == start + 4:
                         eprint('<blue><b>      ...')


### PR DESCRIPTION
Makes error displays shorter, and improves the context for longer ones that are truncated with `...`

## Summary by Sourcery

Shorten and refine compiler error context displays and update the VS Code LSP extension working directory path.

Enhancements:
- Reduce the number of surrounding lines shown in compiler error excerpts to keep displays more concise.
- Adjust truncation boundaries so long error contexts show a more balanced leading and trailing snippet around the focused range.

Chores:
- Update the VS Code LSP client configuration to use the correct koniscript project working directory.